### PR TITLE
Add fix for hanging logback thread in TcpAppender

### DIFF
--- a/src/main/java/com/splunk/logging/TcpAppender.java
+++ b/src/main/java/com/splunk/logging/TcpAppender.java
@@ -128,6 +128,22 @@ public class TcpAppender extends AppenderBase<ILoggingEvent> implements Runnable
             // Exiting.
         }
         addInfo("shutting down");
+
+        // The thread pool used by the default executor spawns non-daemon
+        // threads that prevent appropriate termination of the program.
+        //
+        // To ensure that the program eventually terminates, we reconfigure the
+        // shared executor service to spin down to zero worker threads when no
+        // work is left.
+        //
+        // Can't do this work in the constructor because the context isn't yet set.
+        //
+        // It is possible for someone else to replace the executor, so only
+        // perform this special logic if it looks like we still have the default executor.
+        ExecutorService service = this.getContext().getExecutorService();
+        if (service instanceof ThreadPoolExecutor) {
+            ((ThreadPoolExecutor) service).setCorePoolSize(0);
+        }
     }
 
     @Override


### PR DESCRIPTION
This fixes a bug that was surfaced via testing the Eclipse plugin: DVPL-5767

Unless any object, I'll merge this over next week so we can release the next version of the Eclipse plugin.