### PR TITLE
Performance improvement

### DIFF
--- a/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
+++ b/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
@@ -106,7 +106,7 @@ public class SplunkCimLogEvent {
         addField(THROWABLE_MESSAGE, throwable.getMessage());
 
         StackTraceElement[] elements = throwable.getStackTrace();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int depth = 0; depth < elements.length && depth < stacktraceDepth; depth++) {
             if (depth > 0)
                 sb.append(",");

--- a/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
+++ b/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
@@ -133,7 +133,7 @@ public class SplunkCimLogEvent {
             key = key.replaceAll("\"", "\\\\\"");
             value = value.replaceAll("\"", "\\\\\"");
 
-            output.append(QUOTE + key + KVDELIM + value + QUOTE);
+            output.append(QUOTE).append(key).append(KVDELIM).append(value).append(QUOTE);
         }
 
         return output.toString();

--- a/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
+++ b/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
@@ -18,6 +18,7 @@ package com.splunk.logging;
 
 
 import java.util.LinkedHashMap;
+import java.util.regex.Pattern;
 
 /**
  * <tt>SplunkCimLogEvent</tt> encapsulates the best practice logging semantics recommended by Splunk.
@@ -116,6 +117,7 @@ public class SplunkCimLogEvent {
         addField(THROWABLE_STACKTRACE_ELEMENTS, sb.toString());
     }
 
+    private static final Pattern DOUBLE_QUOTE = Pattern.compile("\"");
     @Override
     public String toString() {
         StringBuilder output = new StringBuilder();
@@ -130,8 +132,8 @@ public class SplunkCimLogEvent {
             String value = entries.get(key).toString();
 
             // Escape any " that appear in the key or value.
-            key = key.replaceAll("\"", "\\\\\"");
-            value = value.replaceAll("\"", "\\\\\"");
+            key = DOUBLE_QUOTE.matcher(key).replaceAll("\\\\\"");
+            value = DOUBLE_QUOTE.matcher(value).replaceAll("\\\\\"");
 
             output.append(QUOTE).append(key).append(KVDELIM).append(value).append(QUOTE);
         }


### PR DESCRIPTION
Here is a set of proposal for performance improvement:

1. Replace `StringBuffer` with `StringBuilder`
2. Stop generating needless `StringBuilder` instance
3. Stop compiling same `Pattern` again and again