### PR TITLE
allow user to send complex json objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.1</version>
                         <configuration>
-                            <source>1.6</source>
+                            <source>1.7</source>
                             <target>1.6</target>
                         </configuration>
                     </plugin>

--- a/src/main/java/com/splunk/logging/HttpEventCollectorErrorHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorErrorHandler.java
@@ -31,7 +31,7 @@ import java.util.List;
  *
  * Usage example:
  * HttpEventCollectorErrorHandler.onError(new HttpEventErrorHandler.ErrorCallback() {
- *     public void error(final String data, final Exception ex) {  handle exception  }
+ *     public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {  handle exception  }
  * });
  */
 public class HttpEventCollectorErrorHandler {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorEventInfo.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorEventInfo.java
@@ -21,17 +21,17 @@ package com.splunk.logging;
 /**
  * Container for Splunk http event collector event data
  */
-public class HttpEventCollectorEventInfo {
+public class HttpEventCollectorEventInfo<E> {
     private double time; // time in "epoch" format
     private final String severity;
-    private final String message;
+    private final E message;
 
     /**
      * Create a new HttpEventCollectorEventInfo container
      * @param severity of event
      * @param message is an event content
      */
-    public HttpEventCollectorEventInfo(final String severity, final String message) {
+    public HttpEventCollectorEventInfo(final String severity, final E message) {
         this.time = System.currentTimeMillis() / 1000.0;
         this.severity = severity;
         this.message = message;
@@ -54,7 +54,7 @@ public class HttpEventCollectorEventInfo {
     /**
      * @return event message
      */
-    public final String getMessage() {
+    public final E getMessage() {
         return message;
     }
 }

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -38,7 +38,7 @@ import java.util.*;
 /**
  * This is an internal helper class that sends logging events to Splunk http event collector.
  */
-final class HttpEventCollectorSender extends TimerTask implements HttpEventCollectorMiddleware.IHttpSender {
+public final class HttpEventCollectorSender<E> extends TimerTask implements HttpEventCollectorMiddleware.IHttpSender {
     public static final String MetadataTimeTag = "time";
     public static final String MetadataIndexTag = "index";
     public static final String MetadataSourceTag = "source";
@@ -133,12 +133,12 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
      * @param severity event severity level (info, warning, etc.)
      * @param message event text
      */
-    public synchronized void send(final String severity, final String message) {
+    public synchronized void send(final String severity, final E message) {
         // create event info container and add it to the batch
         HttpEventCollectorEventInfo eventInfo =
-                new HttpEventCollectorEventInfo(severity, message);
+                new HttpEventCollectorEventInfo<E>(severity, message);
         eventsBatch.add(eventInfo);
-        eventsBatchSize += severity.length() + message.length();
+        eventsBatchSize += severity.length() + message.toString().length();
         if (eventsBatch.size() >= maxEventsBatchCount || eventsBatchSize > maxEventsBatchSize) {
             flush();
         }

--- a/src/test/java/HttpEventCollectorUnitTest.java
+++ b/src/test/java/HttpEventCollectorUnitTest.java
@@ -24,7 +24,6 @@ import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.rmi.runtime.Log;
 
 import java.io.ByteArrayInputStream;
 import java.util.Date;
@@ -52,8 +51,8 @@ public class HttpEventCollectorUnitTest {
             @Override
             public void input(List<HttpEventCollectorEventInfo> events) {
                 Assert.assertTrue(events.size() == 1);
-                Assert.assertTrue(events.get(0).getMessage().compareTo("hello log4j") == 0);
-                Assert.assertTrue(events.get(0).getSeverity().compareTo("INFO") == 0);
+                Assert.assertEquals("hello log4j", events.get(0).getMessage());
+                Assert.assertEquals("INFO",events.get(0).getSeverity());
             }
         };
         LOG4J.info("hello log4j");
@@ -80,8 +79,8 @@ public class HttpEventCollectorUnitTest {
             @Override
             public void input(List<HttpEventCollectorEventInfo> events) {
                 Assert.assertTrue(events.size() == 1);
-                Assert.assertTrue(events.get(0).getMessage().compareTo("hello logback") == 0);
-                Assert.assertTrue(events.get(0).getSeverity().compareTo("ERROR") == 0);
+                Assert.assertEquals("hello logback", events.get(0).getMessage());
+                Assert.assertEquals("ERROR", events.get(0).getSeverity());
             }
         };
         LOGBACK.error("hello logback");
@@ -109,8 +108,8 @@ public class HttpEventCollectorUnitTest {
             @Override
             public void input(List<HttpEventCollectorEventInfo> events) {
                 Assert.assertTrue(events.size() == 1);
-                Assert.assertTrue(events.get(0).getMessage().compareTo("hello java logger") == 0);
-                Assert.assertTrue(events.get(0).getSeverity().compareTo("WARNING") == 0);
+                Assert.assertEquals("hello java logger", events.get(0).getMessage());
+                Assert.assertEquals("WARNING", events.get(0).getSeverity());
             }
         };
         LOGGER.warning("hello java logger");
@@ -173,8 +172,8 @@ public class HttpEventCollectorUnitTest {
             int retries = 0;
             @Override
             public void input(List<HttpEventCollectorEventInfo> events) {
-                Assert.assertTrue(events.get(0).getMessage().compareTo("hello") == 0);
-                Assert.assertTrue(events.get(0).getSeverity().compareTo("INFO") == 0);
+                Assert.assertEquals("hello",events.get(0).getMessage());
+                Assert.assertEquals("INFO", events.get(0).getSeverity());
             }
             @Override
             public HttpEventCollectorUnitTestMiddleware.HttpResponse output() {
@@ -212,8 +211,8 @@ public class HttpEventCollectorUnitTest {
         HttpEventCollectorUnitTestMiddleware.io = new HttpEventCollectorUnitTestMiddleware.IO() {
             @Override
             public void input(List<HttpEventCollectorEventInfo> events) {
-                Assert.assertTrue(events.get(0).getMessage().compareTo("hello") == 0);
-                Assert.assertTrue(events.get(0).getSeverity().compareTo("INFO") == 0);
+                Assert.assertEquals("hello", events.get(0).getMessage());
+                Assert.assertEquals("INFO", events.get(0).getSeverity());
             }
             @Override
             public HttpEventCollectorUnitTestMiddleware.HttpResponse output() {
@@ -248,9 +247,9 @@ public class HttpEventCollectorUnitTest {
             @Override
             public void input(List<HttpEventCollectorEventInfo> events) {
                 Assert.assertTrue(events.size() == 3);
-                Assert.assertTrue(events.get(0).getMessage().compareTo("one") == 0);
-                Assert.assertTrue(events.get(1).getMessage().compareTo("two") == 0);
-                Assert.assertTrue(events.get(2).getMessage().compareTo("three") == 0);
+                Assert.assertEquals("one",events.get(0).getMessage());
+                Assert.assertEquals("two",events.get(1).getMessage());
+                Assert.assertEquals("three",events.get(2).getMessage());
             }
         };
         LOGGER.info("one");


### PR DESCRIPTION
currently the message is limited to string, and we want to send complex json object to splunk for JSON indexing.
instead of 
{"severity":"INFO","message":"{\"line_number\":11,\"text\":\"Finished: SUCCESS\",\"build_url\":\"job\/stream_log_poc\/11\/\"}"}

we want to send this
{"severity":"INFO","message":{"line_number":11,"text":"Finished: SUCCESS","build_url":"job/stream_log_poc/11/" } }