### PR TITLE
Make additional parameters optional, on by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.splunk.logging</groupId>
   <artifactId>splunk-library-javalogging</artifactId>
-  <version>1.5.2</version>
+  <version>1.5.2-hf2</version>
   <packaging>jar</packaging>
 
   <name>Splunk Logging for Java</name>

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -181,7 +181,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
         // if an exception was thrown
         this.sender.send(
                 event.getLevel().toString(),
-                event.getMessage().getFormattedMessage(),
+                getLayout().toSerializable(event).toString(),
                 includeLoggerName ? event.getLoggerName() : null,
                 includeThreadName ? event.getThreadName() : null,
                 includeMDC ? event.getContextMap() : null,

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -29,6 +29,10 @@ import java.util.Hashtable;
 public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEvent> {
     private HttpEventCollectorSender sender = null;
     private Layout<ILoggingEvent> _layout;
+    private boolean _includeLoggerName = true;
+    private boolean _includeThreadName = true;
+    private boolean _includeMDC = true;
+    private boolean _includeException = true;
     private String _source;
     private String _sourcetype;
     private String _host;
@@ -101,10 +105,10 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
             this.sender.send(
                     event.getLevel().toString(),
                     _layout.doLayout(event),
-                    event.getLoggerName(),
-                    event.getThreadName(),
-                    event.getMDCPropertyMap(),
-                    event.getThrowableProxy() == null ? null : event.getThrowableProxy().getMessage(),
+                    _includeLoggerName ? event.getLoggerName() : null,
+                    _includeThreadName ? event.getThreadName() : null,
+                    _includeMDC ? event.getMDCPropertyMap() : null,
+                    (!_includeException || event.getThrowableProxy() == null) ? null : event.getThrowableProxy().getMessage(),
                     c.convert(event)
                     );
         }
@@ -132,6 +136,38 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
 
     public Layout<ILoggingEvent> getLayout() {
         return this._layout;
+    }
+
+    public boolean getIncludeLoggerName() {
+        return _includeLoggerName;
+    }
+
+    public void setIncludeLoggerName(boolean includeLoggerName) {
+        this._includeLoggerName = includeLoggerName;
+    }
+
+    public boolean getIncludeThreadName() {
+        return _includeThreadName;
+    }
+
+    public void setIncludeThreadName(boolean includeThreadName) {
+        this._includeThreadName = includeThreadName;
+    }
+
+    public boolean getIncludeMDC() {
+        return _includeMDC;
+    }
+
+    public void setIncludeMDC(boolean includeMDC) {
+        this._includeMDC = includeMDC;
+    }
+
+    public boolean getIncludeException() {
+        return _includeException;
+    }
+
+    public void setIncludeException(boolean includeException) {
+        this._includeException = includeException;
     }
 
     public void setSource(String source) {


### PR DESCRIPTION
Additional parameters - logger name, MDC, thread name etc. - are good, but there should be a way to turn them off if they are not needed. These parameters were absent at all in 1.5.0, so it's strange to see them included in a maintenance (not even a minor) release without any possibility to turn them off.

In this pull request I made a small change to the appender classes, providing a way to disable including additional parameters into the message.