### PR TITLE
Issue #48 Fix - Added handling for JSON messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ target
 pom.xml.old
 pom.xml.orig
 TODOS
+
+# Ignore Eclipse IDE config files
+.classpath
+.project
+.settings

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Log4j and Logback are thread-safe.
 
 ### Sending events to HTTP Event Collector
 
-HTTP Event Collector requires Splunk 6.3+. Splunk Java library supports sending
+[HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) requires Splunk 6.3+. Splunk Java library supports sending
 events through `java.util.logging`, `log4j` and `logback` standard loggers. 
 In order to use HTTP Event Collector it has to be enabled on the server and an 
 application token should be created.
@@ -80,6 +80,33 @@ Sending events is simple:
 Logger LOGGER = java.util.logging.Logger.getLogger("splunk.java.util");
 LOGGER.info("hello world");
 ```
+
+Logback configuration looks like:
+
+```xml
+      <!-- Splunk HTTP Appender -->
+        <appender name="splunkHttpAppender" class="com.splunk.logging.HttpEventCollectorLogbackAppender">
+           <url>${lsplunk.http.url}</url>
+           <token>${splunk.http.token}</token>
+           <source>${splunk.source}</source>
+           <host>${splunk.httpevent.listener.host}</host>
+           <messageFormat>${splunk.event.message.format}</messageFormat>
+           <disableCertificateValidation>${splunk.cert.disable-validation}</disableCertificateValidation>
+           <layout class="ch.qos.logback.classic.PatternLayout">
+              <pattern>%date{ISO8601} [%thread] %level: %msg%n</pattern>
+           </layout>
+        </appender>
+        
+        <logger name="com.example.app" additivity="false" level="INFO">
+            <appender-ref ref="splunkHttpAppender"/>
+        </logger>
+        
+        <root level="INFO">
+            <appender-ref ref="splunkHttpAppender"/>
+        </root>
+```
+#### Message Format
+An event message format could be configured for HTTP event appender in logging framework configuration. It could have one of the two possible values - text, json. It is an optional property with default value as 'text'. Message format 'json' is used where the event message could be in json format.
 
 For more information, see http://dev.splunk.com/view/SP-CAAAE2K.
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -49,7 +49,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
                          final String token,
                          final String source,
                          final String sourcetype,
-                         final String messageMimeType,
+                         final String messageFormat,
                          final String host,
                          final String index,
                          final Filter filter,
@@ -74,7 +74,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
         metadata.put(HttpEventCollectorSender.MetadataIndexTag, index != null ? index : "");
         metadata.put(HttpEventCollectorSender.MetadataSourceTag, source != null ? source : "");
         metadata.put(HttpEventCollectorSender.MetadataSourceTypeTag, sourcetype != null ? sourcetype : "");
-        metadata.put(HttpEventCollectorSender.MetadataMessageMimeTypeTag, messageMimeType != null ? messageMimeType : "");
+        metadata.put(HttpEventCollectorSender.MetadataMessageFormatTag, messageFormat != null ? messageFormat : "");
 
         this.sender = new HttpEventCollectorSender(url, token, batchInterval, batchCount, batchSize, sendMode, metadata);
 
@@ -113,7 +113,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
             @PluginAttribute("name") final String name,
             @PluginAttribute("source") final String source,
             @PluginAttribute("sourcetype") final String sourcetype,
-            @PluginAttribute(HttpEventCollectorSender.MetadataMessageMimeTypeTag) final String messageMimeType,
+            @PluginAttribute(HttpEventCollectorSender.MetadataMessageFormatTag) final String messageFormat,
             @PluginAttribute("host") final String host,
             @PluginAttribute("index") final String index,
             @PluginAttribute("ignoreExceptions") final String ignore,
@@ -160,7 +160,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
 
         return new HttpEventCollectorLog4jAppender(
                 name, url, token,
-                source, sourcetype, messageMimeType, host, index,
+                source, sourcetype, messageFormat, host, index,
                 filter, layout, 
                 includeLoggerName, includeThreadName, includeMDC, includeException, includeMarker,  
                 ignoreExceptions,

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -49,6 +49,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
                          final String token,
                          final String source,
                          final String sourcetype,
+                         final String messageMimeType,
                          final String host,
                          final String index,
                          final Filter filter,
@@ -73,6 +74,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
         metadata.put(HttpEventCollectorSender.MetadataIndexTag, index != null ? index : "");
         metadata.put(HttpEventCollectorSender.MetadataSourceTag, source != null ? source : "");
         metadata.put(HttpEventCollectorSender.MetadataSourceTypeTag, sourcetype != null ? sourcetype : "");
+        metadata.put(HttpEventCollectorSender.MetadataMessageMimeTypeTag, messageMimeType != null ? messageMimeType : "");
 
         this.sender = new HttpEventCollectorSender(url, token, batchInterval, batchCount, batchSize, sendMode, metadata);
 
@@ -111,6 +113,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
             @PluginAttribute("name") final String name,
             @PluginAttribute("source") final String source,
             @PluginAttribute("sourcetype") final String sourcetype,
+            @PluginAttribute(HttpEventCollectorSender.MetadataMessageMimeTypeTag) final String messageMimeType,
             @PluginAttribute("host") final String host,
             @PluginAttribute("index") final String index,
             @PluginAttribute("ignoreExceptions") final String ignore,
@@ -157,7 +160,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
 
         return new HttpEventCollectorLog4jAppender(
                 name, url, token,
-                source, sourcetype, host, index,
+                source, sourcetype, messageMimeType, host, index,
                 filter, layout, 
                 includeLoggerName, includeThreadName, includeMDC, includeException, includeMarker,  
                 ignoreExceptions,

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -35,6 +35,7 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
     private boolean _includeException = true;
     private String _source;
     private String _sourcetype;
+    private String _messageMimeType;
     private String _host;
     private String _index;
     private String _url;
@@ -65,6 +66,9 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
 
         if (_sourcetype != null)
             metadata.put(HttpEventCollectorSender.MetadataSourceTypeTag, _sourcetype);
+        
+        if (_messageMimeType != null)
+            metadata.put(HttpEventCollectorSender.MetadataMessageMimeTypeTag, _messageMimeType);
 
         this.sender = new HttpEventCollectorSender(
                 _url, _token, _batchInterval, _batchCount, _batchSize, _sendMode, metadata);
@@ -184,6 +188,14 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
 
     public String getSourcetype() {
         return this._sourcetype;
+    }
+    
+    public void setMessageMimeType(String messageMimeType) {
+        this._messageMimeType = messageMimeType;
+    }
+
+    public String getMessageMimeType() {
+        return this._messageMimeType;
     }
 
     public void setHost(String host) {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -35,7 +35,7 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
     private boolean _includeException = true;
     private String _source;
     private String _sourcetype;
-    private String _messageMimeType;
+    private String _messageFormat;
     private String _host;
     private String _index;
     private String _url;
@@ -67,8 +67,8 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
         if (_sourcetype != null)
             metadata.put(HttpEventCollectorSender.MetadataSourceTypeTag, _sourcetype);
         
-        if (_messageMimeType != null)
-            metadata.put(HttpEventCollectorSender.MetadataMessageMimeTypeTag, _messageMimeType);
+        if (_messageFormat != null)
+            metadata.put(HttpEventCollectorSender.MetadataMessageFormatTag, _messageFormat);
 
         this.sender = new HttpEventCollectorSender(
                 _url, _token, _batchInterval, _batchCount, _batchSize, _sendMode, metadata);
@@ -190,12 +190,12 @@ public class HttpEventCollectorLogbackAppender extends AppenderBase<ILoggingEven
         return this._sourcetype;
     }
     
-    public void setMessageMimeType(String messageMimeType) {
-        this._messageMimeType = messageMimeType;
+    public void setMessageFormat(String messageFormat) {
+        this._messageFormat = messageFormat;
     }
 
-    public String getMessageMimeType() {
-        return this._messageMimeType;
+    public String getMessageFormat() {
+        return this._messageFormat;
     }
 
     public void setHost(String host) {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
@@ -126,9 +126,9 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
         metadata.put(HttpEventCollectorSender.MetadataSourceTypeTag,
                 getConfigurationProperty(HttpEventCollectorSender.MetadataSourceTypeTag, ""));
         
-        // Extract message mime-type value
-        metadata.put(HttpEventCollectorSender.MetadataMessageMimeTypeTag,
-            getConfigurationProperty(HttpEventCollectorSender.MetadataMessageMimeTypeTag, ""));
+        // Extract message format value
+        metadata.put(HttpEventCollectorSender.MetadataMessageFormatTag,
+            getConfigurationProperty(HttpEventCollectorSender.MetadataMessageFormatTag, ""));
 
         // http event collector endpoint properties
         String url = getConfigurationProperty(UrlConfTag, null);

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
@@ -125,6 +125,10 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
 
         metadata.put(HttpEventCollectorSender.MetadataSourceTypeTag,
                 getConfigurationProperty(HttpEventCollectorSender.MetadataSourceTypeTag, ""));
+        
+        // Extract message mime-type value
+        metadata.put(HttpEventCollectorSender.MetadataMessageMimeTypeTag,
+            getConfigurationProperty(HttpEventCollectorSender.MetadataMessageMimeTypeTag, ""));
 
         // http event collector endpoint properties
         String url = getConfigurationProperty(UrlConfTag, null);

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -55,7 +55,7 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
     public static final String MetadataIndexTag = "index";
     public static final String MetadataSourceTag = "source";
     public static final String MetadataSourceTypeTag = "sourcetype";
-    public static final String MetadataMessageMimeTypeTag = "messageMimeType";
+    public static final String MetadataMessageFormatTag = "messageFormat";
     private static final String AuthorizationHeaderTag = "Authorization";
     private static final String AuthorizationHeaderScheme = "Splunk %s";
     private static final String HttpEventCollectorUriPath = "/services/collector/event/1.0";
@@ -76,35 +76,35 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
     
     /**
      * 
-     * Mime type of the event message. It is used to apply necessary parsing and formatting to the message, if required for the
-     * message mime-type.
+     * Format of the event message. It is used to apply necessary parsing and formatting to the message, if required for the
+     * message format.
      * <p>
-     * If mime-type is not set, then it is assumed to be "text"
+     * If format is not set, then it is assumed to be "text"
      * </p>
      *
      */
-    public enum MessageMimeType {
+    public enum MessageFormat {
         
         TEXT("text"),
         JSON("json");
 
-        private final String mimeType;
+        private final String format;
 
-        MessageMimeType(final String mimeType) {
-            this.mimeType = mimeType;
+        MessageFormat(final String format) {
+            this.format = format;
         }
 
         /**
-         * Gets MessageMimeType instance from string mime-type.
+         * Gets MessageFormat instance from string format.
          *
-         * @param mimeType the message mime-type
-         * @return the message mime-type
+         * @param format the message format
+         * @return the message format
          */
-        public static MessageMimeType fromMimeType(final String mimeType) {
-            if (mimeType != null && mimeType.trim().length() > 0) {
-                for (final MessageMimeType mimeEnum : values()) {
-                    if (mimeEnum.mimeType.equals(mimeType)) {
-                        return mimeEnum;
+        public static MessageFormat fromFormat(final String format) {
+            if (format != null && format.trim().length() > 0) {
+                for (final MessageFormat formatEnum : values()) {
+                    if (formatEnum.format.equals(format)) {
+                        return formatEnum;
                     }
                 }
             }
@@ -267,9 +267,9 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
         putIfPresent(event, MetadataSourceTag, metadata.get(MetadataSourceTag));
         putIfPresent(event, MetadataSourceTypeTag, metadata.get(MetadataSourceTypeTag));
         
-        final String messageMimeType = metadata.get(MetadataMessageMimeTypeTag);
-        // Parse message on the basis of mime-type
-        final Object parsedMessage = parseEventMessage(eventInfo.getMessage(), messageMimeType);
+        final String messageFormat = metadata.get(MetadataMessageFormatTag);
+        // Parse message on the basis of format
+        final Object parsedMessage = parseEventMessage(eventInfo.getMessage(), messageFormat);
         
         // event body
         JSONObject body = new JSONObject();
@@ -299,29 +299,29 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
     }
 
     /**
-     * Parses the event message on the basis of message mime-type.
+     * Parses the event message on the basis of message format.
      * 
      * @param message the event message string
-     * @param messageMimeType the event message mime-type
+     * @param format the event message format
      * 
-     * @return parsed event message based on mime-type
+     * @return parsed event message based on format
      */
-    private Object parseEventMessage(final String message, final String messageMimeType) {
+    private Object parseEventMessage(final String message, final String format) {
         // if message is null or blank then return without parsing
         if (message == null || message.trim().length() == 0) {
             return message;
         }
 
-        // Get mime-type enum from mime-type string
-        final MessageMimeType mimeType = MessageMimeType.fromMimeType(messageMimeType);
+        // Get MessageFormat enum from format string
+        final MessageFormat messageFormat = MessageFormat.fromFormat(format);
 
-        switch (mimeType) {
+        switch (messageFormat) {
             case JSON:
                 return parseJsonEventMessage(message);
 
             case TEXT:
             default:
-                // Treat message type as text if mime-type is not defined or defined as text
+                // Treat message type as text if format is not defined or defined as text
                 return message;
         }
     }

--- a/src/test/java/HttpEventCollector_JavaLoggingTest.java
+++ b/src/test/java/HttpEventCollector_JavaLoggingTest.java
@@ -18,6 +18,8 @@ import java.util.*;
 
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
+
+import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -330,13 +332,16 @@ public final class HttpEventCollector_JavaLoggingTest {
                 break;
             Thread.sleep(1000);
         }
+        
+        // Enable httpEventCollector endpoint
+        TestUtil.enableHttpEventCollector();
 
         if (logEx == null)
             Assert.fail("didn't catch errors");
         Assert.assertEquals(1, errors.size());
 
         System.out.println(logEx.toString());
-        if(!logEx.toString().contains("Connection refused"))
+        if(!logEx.toString().contains("Connection refused") && !logEx.toString().contains("Connection closed"))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 
@@ -425,4 +430,58 @@ public final class HttpEventCollector_JavaLoggingTest {
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
         System.out.println("====================== Test pass=========================");
     }
+    
+    /**
+     * Test sending a JSON and text message with "_json" source type via http logging appender using java util logger
+     */
+    @Test
+    public void canSendJsonEventUsingUtilLoggerWithJsonSourceType() throws Exception {
+        canSendJsonEventUsingUtilLoggerWithSourceType("_json");
+    }
+    
+    /**
+     * Test sending a JSON and text message with "battlecat_test" source type via http logging appender using java util logger
+     */
+    @Test
+    public void canSendJsonEventUsingUtilLoggerWithDefaultSourceType() throws Exception {
+        canSendJsonEventUsingUtilLoggerWithSourceType("battlecat_test");
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void canSendJsonEventUsingUtilLoggerWithSourceType(final String sourceType) throws Exception {
+        final String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
+
+        final String loggerName = "javaUtilLogger";
+        // Build User input map
+        final HashMap<String, String> userInputs = TestUtil.buildUserInputMap(loggerName, token, sourceType, "json");
+        
+        TestUtil.resetJavaLoggingConfiguration("logging_template.properties", "logging.properties", userInputs);
+
+        final List<String> msgs = new ArrayList<String>();
+
+        final long timeMillsec = new Date().getTime();
+
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put("transactionId", "11");
+        jsonObject.put("userId", "21");
+        jsonObject.put("eventTimestap", timeMillsec);
+
+        final Logger logger = Logger.getLogger(loggerName);
+
+        // Test with a json event message
+        jsonObject.put("severity", "info");
+        final String infoJson = jsonObject.toString();
+        logger.info(infoJson);
+        msgs.add(infoJson);
+
+        // Test with a text event message
+        jsonObject.put("severity", "info");
+        final String infoText = String.format("{EventTimestamp:%s, EventMsg:'this is a text info for java util logger}", timeMillsec);
+        logger.info(infoText);
+        msgs.add(infoText);
+
+        TestUtil.verifyEventsSentToSplunk(msgs);
+        TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
+    }
+    
 }

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -328,7 +328,7 @@ public final class HttpEventCollector_Log4j2Test {
         Assert.assertTrue(errors.size() >= 1);
 
         System.out.println(logEx.toString());
-        if(!logEx.toString().contains("Connection refused"))
+        if(!logEx.toString().contains("Connection refused") && !logEx.toString().contains("Connection closed"))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 

--- a/src/test/java/HttpEventCollector_LogbackTest.java
+++ b/src/test/java/HttpEventCollector_LogbackTest.java
@@ -18,6 +18,8 @@ import java.util.*;
 
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
+
+import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -311,12 +313,14 @@ public final class HttpEventCollector_LogbackTest {
             Thread.sleep(1000);
         }
 
+        TestUtil.enableHttpEventCollector();
+        
         if (logEx == null)
             Assert.fail("didn't catch errors");
         Assert.assertEquals(1, errors.size());
 
         System.out.println(logEx.toString());
-        if(!logEx.toString().contains("Connection refused"))
+        if(!logEx.toString().contains("Connection refused") && !logEx.toString().contains("Connection closed"))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 
@@ -356,5 +360,64 @@ public final class HttpEventCollector_LogbackTest {
 
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
         System.out.println("====================== Test pass=========================");
+    }
+    
+    /**
+     * Test sending a JSON and text message with "_json" source type via http logging appender using logback
+     */
+    @Test
+    public void canSendJsonEventUsingLogbackWithJsonSourceType() throws Exception {
+        canSendJsonEventUsingLogbackWithSourceType("_json");
+    }
+    
+    /**
+     * Test sending a JSON and text message with "battlecat_test" source type via http logging appender using logback
+     */
+    @Test
+    public void canSendJsonEventUsingLogbackWithDefaultSourceType() throws Exception {
+        canSendJsonEventUsingLogbackWithSourceType("battlecat_test");
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void canSendJsonEventUsingLogbackWithSourceType(final String sourceType) throws Exception {
+        String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
+
+        final String loggerName = "logBackLogger";
+
+        // Build User input map
+        final HashMap<String, String> userInputs = TestUtil.buildUserInputMap(loggerName, token, sourceType, "json");
+
+        TestUtil.resetLogbackConfiguration("logback_template.xml", "logback.xml", userInputs);
+
+        final List<String> msgs = new ArrayList<String>();
+
+        final long timeMillsec = new Date().getTime();
+
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put("transactionId", "11");
+        jsonObject.put("userId", "21");
+        jsonObject.put("eventTimestap", timeMillsec);
+
+        final Logger logger = LoggerFactory.getLogger(loggerName);
+
+        // Test with a json event message
+        jsonObject.put("severity", "info");
+        final String infoJson = jsonObject.toString();
+        logger.info(infoJson);
+        msgs.add(infoJson);
+
+        jsonObject.put("severity", "error");
+        final String errorJson = jsonObject.toString();
+        logger.error(errorJson);
+        msgs.add(errorJson);
+
+        // Test with a text event message
+        jsonObject.put("severity", "debug");
+        final String debugText = String.format("{EventTimestamp:%s, EventMsg:'this is a test debug for Logback Test}", timeMillsec);
+        logger.debug(debugText);
+        msgs.add(debugText);
+
+        TestUtil.verifyEventsSentToSplunk(msgs);
+        TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
     }
 }

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -18,6 +18,9 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import com.splunk.*;
+
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
 import org.junit.Assert;
 import org.slf4j.*;
 
@@ -25,6 +28,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.logging.LogManager;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -371,8 +375,14 @@ public class TestUtil {
             int eventCount = 0;
             InputStream resultsStream = null;
             ResultsReaderXml resultsReader = null;
+            final Object parsedObject = JSONValue.parse(msg);
             while (System.currentTimeMillis() - startTime < 30 * 1000)/*wait for up to 30s*/ {
-                resultsStream = service.oneshotSearch("search " + msg);
+                if (parsedObject instanceof JSONObject) {
+                    resultsStream = searchJsonMessageEvent((JSONObject) parsedObject);
+                } else {
+                    resultsStream = service.oneshotSearch("search " + msg);
+                }
+                
                 resultsReader = new ResultsReaderXml(resultsStream);
 
                 //verify has one and only one record return
@@ -389,8 +399,31 @@ public class TestUtil {
             resultsReader.close();
             resultsStream.close();
 
-            Assert.assertTrue(eventCount == 1);
+            Assert.assertEquals("Event search results did not match.", 1, eventCount);
         }
+    }
+
+    /**
+     * Search JSON message event.
+     *
+     * @param jsonObject the JSON event object
+     * @return the input stream linked with the search result
+     */
+    @SuppressWarnings("rawtypes")
+    private static InputStream searchJsonMessageEvent(final JSONObject jsonObject) {
+        String searchQuery = "";
+        boolean firstSearchTerm = true;
+        for (final Object entryObject : jsonObject.entrySet()) {
+            final Entry jsonEntry = (Entry) entryObject;
+             if (firstSearchTerm) {
+                 searchQuery += String.format("search \"message.%s\"=%s", jsonEntry.getKey(), jsonEntry.getValue());
+                 firstSearchTerm = false;
+             } else {
+                 searchQuery += String.format(" | search \"message.%s\"=%s", jsonEntry.getKey(), jsonEntry.getValue());
+             }
+        }
+        
+        return service.oneshotSearch(searchQuery);
     }
 
     public static void verifyEventsSentInOrder(String prefix, int totalEventsCount, String index) throws IOException {
@@ -425,5 +458,25 @@ public class TestUtil {
             assert results.get(i).contains(expect) :
                     String.format("expect: %s, actual: %s", expect, results.get(i));
         }
+    }
+    
+    
+    /**
+     * Builds user input map using specified parameters.
+     *
+     * @param loggerName the logger name
+     * @param token the event collector token
+     * @param sourceType the source type
+     * @return the hash map
+     */
+    public static HashMap<String, String> buildUserInputMap(final String loggerName, final String token, final String sourceType, final String messageFormat) {
+        final HashMap<String, String> userInputs = new HashMap<String, String>();
+        userInputs.put("user_logger_name", loggerName);
+        userInputs.put("user_httpEventCollector_token", token);
+        userInputs.put("user_host", "host.example.com");
+        userInputs.put("user_source", "splunktest");
+        userInputs.put("user_sourcetype", sourceType);
+        userInputs.put("user_messageFormat", messageFormat);
+        return userInputs;
     }
 }

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -15,7 +15,7 @@ License for the specific language governing permissions and limitations
 under the License.
 -->
 
-<Configuration status="info" name="example" packages="">
+<Configuration status="info" name="example" packages="com.splunk.logging">
     <!-- Define an appender that writes to a TCP socket. We use Log4J's SocketAppender, which
          is documented at
 
@@ -39,6 +39,7 @@ under the License.
               index=""
               source="splunktest"
               sourcetype="battlecat"
+              messageFormat="text"
               middleware="HttpEventCollectorUnitTestMiddleware"
               batch_size_bytes="0"
               batch_size_count="0"

--- a/src/test/resources/log4j2_template.xml
+++ b/src/test/resources/log4j2_template.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="info" name="example" packages="">
+<Configuration status="info" name="example" packages="com.splunk.logging">
     <Appenders>
         <Http
               name="httpconf"
               url="%scheme%://%host%:8088"
               token="%user_httpEventCollector_token%"
-
               host="%user_host%"
               index="%user_index%"
               source="%user_source%"
               sourcetype="%user_sourcetype%"
+              messageFormat="%user_messageFormat%"
               batch_interval="%user_batch_interval%"
               batch_size_bytes="%user_batch_size_bytes%"
               batch_size_count="%user_batch_size_count%"

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -57,6 +57,7 @@ under the License.
         <token>11111111-2222-3333-4444-555555555555</token>
         <source>splunktest</source>
         <sourcetype>battlecat</sourcetype>
+        <messageFormat>text</messageFormat>
         <middleware>HttpEventCollectorUnitTestMiddleware</middleware>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%msg</pattern>

--- a/src/test/resources/logback_template.xml
+++ b/src/test/resources/logback_template.xml
@@ -8,7 +8,8 @@
         <host>%user_host%</host>
         <index>%user_index%</index>
         <source>splunktest_accept</source>
-        <sourcetype>battlecat_test</sourcetype>
+        <sourcetype>%user_sourcetype%</sourcetype>
+        <messageFormat>%user_messageFormat%</messageFormat>
         <disableCertificateValidation>true</disableCertificateValidation>
         <batch_interval>%user_batch_interval%</batch_interval>
         <batch_size_bytes>%user_batch_size_bytes%</batch_size_bytes>

--- a/src/test/resources/logging_template.properties
+++ b/src/test/resources/logging_template.properties
@@ -9,6 +9,7 @@ com.splunk.logging.HttpEventCollectorLoggingHandler.level = INFO
 com.splunk.logging.HttpEventCollectorLoggingHandler.token = %user_httpEventCollector_token%
 com.splunk.logging.HttpEventCollectorLoggingHandler.source = %user_source%
 com.splunk.logging.HttpEventCollectorLoggingHandler.sourcetype = %user_sourcetype%
+com.splunk.logging.HttpEventCollectorLoggingHandler.messageFormat = %user_messageFormat%
 com.splunk.logging.HttpEventCollectorLoggingHandler.batch_interval=%user_batch_interval%
 com.splunk.logging.HttpEventCollectorLoggingHandler.batch_size_bytes=%user_batch_size_bytes%
 com.splunk.logging.HttpEventCollectorLoggingHandler.batch_size_count=%user_batch_size_count%


### PR DESCRIPTION
The Splunk appenders for HTTP Event collector does not handle messages in Json format properly. The format literals are escaped in the Json message and sent over to Http event collector which, due to escape characters, treats the incoming message as normal text.

I have introduced a new appender configuration property "messageFormat" that takes one of the two possible values at the moment - text or json. If not specified, the default is "text". This approach allows to do necessary parsing and formatting on the basis of message format and allow extending it to more formats in future, if needed.