### PR TITLE
Handle both ILoggingEvent and IAccessEvent so that logback-access can…

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,41 @@ entries.
         setAuthAction("deny");
     }});
    ```
+  
+### Using logback-access with HEC appender
+[logback-access](https://logback.qos.ch/access.html) logs different type of events (`ch.qos.logback.access.spi.IAccessEvent`) as logback classic, which logs `ch.qos.logback.classic.spi.ILoggingEvent`. 
+
+To use this library with logback-access, you can try the following configuration:
+
+* logback access (to be put in `logback-access.xml` on the classpath)
+   ```
+    <configuration>
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>combined</pattern>
+            </encoder>
+        </appender>
+    
+        <appender name="hec_access_appender" class="com.splunk.logging.HttpEventCollectorLogbackAppender">
+            <url>https://localhost:8088</url>
+            <token>00000000-0000-0000-0000-000000000000</token>
+            <host>devhost</host>
+            <index>main</index>
+            <source>logback-client</source>
+            <sourcetype>logback</sourcetype>
+            <disableCertificateValidation>true</disableCertificateValidation>
+    
+            <layout class="ch.qos.logback.access.PatternLayout">
+                <pattern>%h %l %u %t %r %s %b</pattern>
+            </layout>
+        </appender>
+    
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="hec_access_appender" />
+    </configuration>
+   ```
+    If you run into any issue, try add a `debug=true` attribute to the `configuration` for debugging.
+
 
 ## Splunk Enterprise
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.splunk.logging</groupId>
   <artifactId>splunk-library-javalogging</artifactId>
-  <version>1.5.2-hf2</version>
+  <version>1.5.2-hf3</version>
   <packaging>jar</packaging>
 
   <name>Splunk Logging for Java</name>
@@ -16,6 +16,7 @@
 
     <properties>
         <maven.resources.overwrite>true</maven.resources.overwrite>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <profiles>
         <profile>
@@ -136,13 +137,19 @@
       <dependency>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
-          <version>1.0.13</version>
+          <version>1.1.11</version>
           <scope>provided</scope>
       </dependency>
       <dependency>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-core</artifactId>
-          <version>1.0.13</version>
+          <version>1.1.11</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-access</artifactId>
+          <version>1.1.11</version>
           <scope>provided</scope>
       </dependency>
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -163,6 +163,15 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
     }
 
     /**
+     * Send a single logging event with message only
+     * @note in case of batching the event isn't sent immediately
+     * @param message event text
+     */
+    public synchronized void send(final String message) {
+        send("", message, "", "", null, null, "");
+    }
+
+    /**
      * Flush all pending events
      */
     public synchronized void flush() {


### PR DESCRIPTION
[logback-access](https://logback.qos.ch/access.html) library logs `ch.qos.logback.access.spi.IAccessEvent` instead of `ch.qos.logback.classic.spi.ILoggingEvent`. Currently, HEC logback appender (`com.splunk.logging.HttpEventCollectorLogbackAppender`) doesn't handle the former class, and will cause some class cast exception like below:

```
09:26:08,363 |-ERROR in com.splunk.logging.HttpEventCollectorLogbackAppender[hec_access_appender] - Appender [hec_access_appender] failed to append. java.lang.ClassCastException: ch.qos.logback.access.spi.AccessEvent cannot be cast to ch.qos.logback.classic.spi.ILoggingEvent
```

To address this issue, the HEC appender was modified to handle both types of events, and users can use the `ch.qos.logback.access.PatternLayout` together with the HEC logback appender (`com.splunk.logging.HttpEventCollectorLogbackAppender`) to collect HTTP access logs.