### PR TITLE
Fixes Cookie Expiry date issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,13 +178,13 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.6</version>
+        <version>4.5.5</version>
        </dependency>
        
        <dependency>
          <groupId>org.apache.httpcomponents</groupId>
          <artifactId>httpasyncclient</artifactId>
-         <version>4.0</version>
+         <version>4.1.3</version>
         </dependency>
 
      <dependency>

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -19,6 +19,8 @@ package com.splunk.logging;
  */
 
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -290,6 +292,7 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
         if (! disableCertificateValidation) {
             // create an http client that validates certificates
             httpClient = HttpAsyncClients.custom()
+                    .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
                     .setMaxConnTotal(maxConnTotal)
                     .build();
         } else {
@@ -305,6 +308,7 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
                 sslContext = SSLContexts.custom().loadTrustMaterial(
                         null, acceptingTrustStrategy).build();
                 httpClient = HttpAsyncClients.custom()
+                        .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
                         .setMaxConnTotal(maxConnTotal)
                         .setHostnameVerifier(SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)
                         .setSSLContext(sslContext)


### PR DESCRIPTION
`Apache HttpClient is too old to setup Expiry date`
https://github.com/splunk/splunk-library-javalogging/issues/60

Ported fix from

`fixed httpclient cookie header expiry problem`
https://github.com/splunk/splunk-library-javalogging/pull/61