### PR TITLE
Add configuration options for HttpClient specific properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,10 +117,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.1</version>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.18.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,26 @@
 
   <groupId>com.splunk.logging</groupId>
   <artifactId>splunk-library-javalogging</artifactId>
-  <version>1.6.0</version>
+  <version>1.7.0</version>
   <packaging>jar</packaging>
 
   <name>Splunk Logging for Java</name>
   <url>http://dev.splunk.com/goto/sdk-slj</url>
 
     <description>Library for structured, semantic logging of Common Information Model compliant events, meant for use with SLF4J.</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <properties>
         <maven.resources.overwrite>true</maven.resources.overwrite>
@@ -26,14 +39,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.1</version>
-                        <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
-                        </configuration>
-                    </plugin>
                    <plugin>
                         <groupId>biz.aQute.bnd</groupId>
                         <artifactId>bnd-maven-plugin</artifactId>
@@ -114,10 +119,6 @@
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.1</version>
-                        <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -66,19 +66,26 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
                          long batchCount,
                          long batchSize,
                          long retriesOnError,
+                         int socketTimeout,
+                         int connectionTimeout,
+                         int connectionRequestTimeout,
+                         int poolMaxConnections,
+                         long poolSelectInterval,
                          String sendMode,
                          String middleware,
                          final String disableCertificateValidation)
     {
         super(name, filter, layout, ignoreExceptions);
-        Dictionary<String, String> metadata = new Hashtable<String, String>();
+        Dictionary<String, String> metadata = new Hashtable<>();
         metadata.put(HttpEventCollectorSender.MetadataHostTag, host != null ? host : "");
         metadata.put(HttpEventCollectorSender.MetadataIndexTag, index != null ? index : "");
         metadata.put(HttpEventCollectorSender.MetadataSourceTag, source != null ? source : "");
         metadata.put(HttpEventCollectorSender.MetadataSourceTypeTag, sourcetype != null ? sourcetype : "");
         metadata.put(HttpEventCollectorSender.MetadataMessageFormatTag, messageFormat != null ? messageFormat : "");
 
-        this.sender = new HttpEventCollectorSender(url, token, channel, type, batchInterval, batchCount, batchSize, sendMode, metadata);
+        this.sender = new HttpEventCollectorSender(url, token, channel, type, batchInterval, 
+            batchCount, batchSize, socketTimeout, connectionTimeout, connectionRequestTimeout, 
+            poolMaxConnections, poolSelectInterval, sendMode, metadata);
 
         // plug a user middleware
         if (middleware != null && !middleware.isEmpty()) {
@@ -125,6 +132,11 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
             @PluginAttribute("batch_size_count") final String batchCount,
             @PluginAttribute("batch_interval") final String batchInterval,
             @PluginAttribute("retries_on_error") final String retriesOnError,
+            @PluginAttribute(value = "socket_timeout", defaultInt =  -1) final int socketTimeout,
+            @PluginAttribute(value = "connection_timeout", defaultInt = -1) final int connectionTimeout,
+            @PluginAttribute(value = "connection_request_timeout", defaultInt = -1) final int connectionRequestTimeout,
+            @PluginAttribute(value = "pool_select_interval", defaultLong = 1000L) final long poolSelectInterval,
+            @PluginAttribute(value = "pool_max_connections", defaultInt = 0) final int poolMaxConnections,
             @PluginAttribute("send_mode") final String sendMode,
             @PluginAttribute("middleware") final String middleware,
             @PluginAttribute("disableCertificateValidation") final String disableCertificateValidation,
@@ -172,6 +184,11 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
                 parseInt(batchCount, HttpEventCollectorSender.DefaultBatchCount),
                 parseInt(batchSize, HttpEventCollectorSender.DefaultBatchSize),
                 parseInt(retriesOnError, 0),
+                socketTimeout,
+                connectionTimeout,
+                connectionRequestTimeout,
+                poolMaxConnections,
+                poolSelectInterval,
                 sendMode,
                 middleware,
                 disableCertificateValidation);

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -51,6 +51,11 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
     private long _batchSize = 0;
     private String _sendMode;
     private long _retriesOnError = 0;
+    private int _socketTimeout = -1;
+    private int _connectionTimeout = -1;
+    private long _poolSelectInterval = 1000L;
+    private int _poolMaxConnections;
+    private int _connectionRequestTimeout = -1;
 
     @Override
     public void start() {
@@ -58,7 +63,7 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
             return;
 
         // init events sender
-        Dictionary<String, String> metadata = new Hashtable<String, String>();
+        Dictionary<String, String> metadata = new Hashtable<>();
         if (_host != null)
             metadata.put(HttpEventCollectorSender.MetadataHostTag, _host);
 
@@ -74,8 +79,9 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
         if (_messageFormat != null)
             metadata.put(HttpEventCollectorSender.MetadataMessageFormatTag, _messageFormat);
 
-        this.sender = new HttpEventCollectorSender(
-                _url, _token, _channel, _type, _batchInterval, _batchCount, _batchSize, _sendMode, metadata);
+        this.sender = new HttpEventCollectorSender(_url, _token, _channel, _type, _batchInterval,
+            _batchCount, _batchSize, _socketTimeout, _connectionTimeout, _connectionRequestTimeout, 
+            _poolMaxConnections, _poolSelectInterval, _sendMode, metadata);
 
         // plug a user middleware
         if (_middleware != null && !_middleware.isEmpty()) {
@@ -287,6 +293,46 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
 
     public String getDisableCertificateValidation() {
         return _disableCertificateValidation;
+    }
+
+    public int getsocket_timeout() {
+        return _socketTimeout;
+    }
+
+    public void setsocket_timeout(int _socketTimeout) {
+        this._socketTimeout = _socketTimeout;
+    }
+
+    public int getconnection_timeout() {
+        return _connectionTimeout;
+    }
+
+    public void setconnection_timeout(int _connectionTimeout) {
+        this._connectionTimeout = _connectionTimeout;
+    }
+
+    public long getpool_select_interval() {
+        return _poolSelectInterval;
+    }
+
+    public void setpool_select_interval(long _poolSelectInterval) {
+        this._poolSelectInterval = _poolSelectInterval;
+    }
+
+    public int getpool_max_connections() {
+        return _poolMaxConnections;
+    }
+
+    public void setpool_max_connections(int _poolMaxConnections) {
+        this._poolMaxConnections = _poolMaxConnections;
+    }
+
+    public int getconnection_request_timeout() {
+        return _connectionRequestTimeout;
+    }
+
+    public void setconnection_request_timeout(int _connectionRequestTimeout) {
+        this._connectionRequestTimeout = _connectionRequestTimeout;
     }
 
     private static long parseLong(String string, int defaultValue) {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
@@ -109,6 +109,11 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
     private final String UrlConfTag = "url";
     private final String SendModeTag = "send_mode";
     private final String MiddlewareTag = "middleware";
+    private final String SocketTimeoutTag = "socket_timeout";
+    private final String ConnectionTimeoutTag = "connection_timeout";
+    private final String ConncetionRequestTimeoutTag = "connection_request_timeout";
+    private final String PoolMaxConnectionsTag = "pool_max_connections";
+    private final String PoolSelectIntervalTag = "pool_select_interval";
 
     /** HttpEventCollectorLoggingHandler c-or */
     public HttpEventCollectorLoggingHandler() {
@@ -153,10 +158,18 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
         includeLoggerName = getConfigurationBooleanProperty(IncludeLoggerNameConfTag, true);
         includeThreadName = getConfigurationBooleanProperty(IncludeThreadNameConfTag, true);
         includeException = getConfigurationBooleanProperty(IncludeExceptionConfTag, true);
+        
+        int socketTimeout = (int)getConfigurationNumericProperty(SocketTimeoutTag, -1);
+        int connectionTimeout = (int)getConfigurationNumericProperty(ConnectionTimeoutTag, -1);
+        int connectionRequestTimeout = (int)getConfigurationNumericProperty(ConncetionRequestTimeoutTag, -1);
+        int poolMaxConnections = (int)getConfigurationNumericProperty(PoolMaxConnectionsTag, 0);
+        long poolSelectInterval = getConfigurationNumericProperty(PoolSelectIntervalTag, 1000L);
 
         // delegate all configuration params to event sender
         this.sender = new HttpEventCollectorSender(
-                url, token, channel, type, delay, batchCount, batchSize, sendMode, metadata);
+                url, token, channel, type, delay, batchCount, batchSize, socketTimeout, 
+                connectionTimeout, connectionRequestTimeout, poolMaxConnections, 
+                poolSelectInterval, sendMode, metadata);
 
         // plug a user middleware
         if (middleware != null && !middleware.isEmpty()) {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -325,12 +325,6 @@ final class HttpEventCollectorSender extends TimerTask implements HttpEventColle
           // http client is already started
           return;
         }
-
-      System.out.println("+++     Conn timeout: " + connectionTimeout);
-      System.out.println("+++     Sock timeout: " + socketTimeout);
-      System.out.println("+++     Cnrq timeout: " + connectionRequestTimeout);
-      System.out.println("+++   Max conn total: " + poolMaxConnections);
-      System.out.println("+++  Select interval: " + poolSelectInterval);
         
         int maxConnTotal = sendMode == SendMode.Sequential ? 1 : poolMaxConnections;
     

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -59,6 +59,11 @@ under the License.
         <sourcetype>battlecat</sourcetype>
         <messageFormat>text</messageFormat>
         <middleware>HttpEventCollectorUnitTestMiddleware</middleware>
+        <socket_timeout>6000</socket_timeout>
+        <connection_timeout>12000</connection_timeout>
+        <connection_request_timeout>3000</connection_request_timeout>
+        <pool_max_connections>128</pool_max_connections>
+        <pool_select_interval>5000</pool_select_interval>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%msg</pattern>
         </layout>

--- a/src/test/resources/logback_template.xml
+++ b/src/test/resources/logback_template.xml
@@ -17,7 +17,11 @@
         <send_mode>%user_send_mode%</send_mode>
         <send_mode>%user_send_mode%</send_mode>
         <middleware>%user_middleware%</middleware>
-
+        <socket_timeout>%user_socket_timeout%</socket_timeout>
+        <connection_timeout>%user_connection_timeout%</connection_timeout>
+        <connection_request_timeout>%user_connection_request_timeout%</connection_request_timeout>
+        <pool_max_connections>%user_pool_max_connections%</pool_max_connections>
+        <pool_select_interval>%user_pool_select_interval%</pool_select_interval>
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%msg</pattern>
         </layout>


### PR DESCRIPTION
**Adding configuration options for HttpClient specific properties to HttpEventCollectorSender through the appenders**:

-  socket timeout (_socket_timeout_)
-  connection timeout (_connection_timeout_)
-  connection request timeout (_connection_request_timeout_)
-  pool max connections (_pool_max_connections_)
-  pool select interval (_pool_select_interval_)

**Main reason:**

While using the current library version, if Splunk server hangs and HttpPost for one event never completes, JVM will eventually run out of memory, because connection has no timeout and, thus, is never failed and reestablished. Since no limit on waiting time is defined for the queued HttpPosts the queue will pile up indefinitely up to the memory limits.

**Other changes**:
- upgraded Java source/target to 1.7
- upgraded library version to 1.7.0