### PR TITLE
Fix 100% CPU usage

### DIFF
--- a/src/main/java/com/splunk/logging/TcpAppender.java
+++ b/src/main/java/com/splunk/logging/TcpAppender.java
@@ -129,23 +129,7 @@ public class TcpAppender extends AppenderBase<ILoggingEvent> implements Runnable
         } catch (InterruptedException ex) {
             // Exiting.
         }
-        addInfo("shutting down");
-
-        // The thread pool used by the default executor spawns non-daemon
-        // threads that prevent appropriate termination of the program.
-        //
-        // To ensure that the program eventually terminates, we reconfigure the
-        // shared executor service to spin down to zero worker threads when no
-        // work is left.
-        //
-        // Can't do this work in the constructor because the context isn't yet set.
-        //
-        // It is possible for someone else to replace the executor, so only
-        // perform this special logic if it looks like we still have the default executor.
-        ExecutorService service = this.getContext().getExecutorService();
-        if (service instanceof ThreadPoolExecutor) {
-            ((ThreadPoolExecutor) service).setCorePoolSize(0);
-        }
+        addInfo("exiting");
     }
 
     private SocketConnector initSocketConnector() {

--- a/src/main/java/com/splunk/logging/TcpAppender.java
+++ b/src/main/java/com/splunk/logging/TcpAppender.java
@@ -236,7 +236,15 @@ public class TcpAppender extends AppenderBase<ILoggingEvent> implements Runnable
         // Dispatch this instance of the appender.
         if (!errorPresent) {
             queue = queueSize <= 0 ? new SynchronousQueue<ILoggingEvent>() : new ArrayBlockingQueue<ILoggingEvent>(queueSize);
-            executor = Executors.newSingleThreadExecutor();
+            ThreadFactory factory = new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r, "splunk-tcp-appender");
+                    t.setDaemon(true);
+                    return t;
+                }
+            };
+            executor = Executors.newSingleThreadExecutor(factory);
             executor.execute(this);
         }
 


### PR DESCRIPTION
We're seeing constant 100% CPU usage of a single core after rereading the logback config file when using the TcpAppender.

This PR removes the workaround from #9 since that should no longer be necessary because of #43.