### PR TITLE
Replace hashtable and make test compatible with Java6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,14 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
+            <version>3.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- gson dependency not declared in splunk module -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2.4</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -231,12 +231,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.4</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.5</version>

--- a/src/main/java/com/splunk/logging/HttpEventCollectorEventInfo.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorEventInfo.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Container for Splunk http event collector event data
  */
 public class HttpEventCollectorEventInfo {
-    private double time; // time in fractional seconds since "unix epoch" format
+    private final double time; // time in fractional seconds since "unix epoch" format
     private final String severity;
     private final String message;
     private final String logger_name;

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -17,8 +17,7 @@ package com.splunk.logging;
 
 import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.util.Dictionary;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.Filter;
@@ -72,7 +71,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
                          final String eventBodySerializer)
     {
         super(name, filter, layout, ignoreExceptions);
-        Dictionary<String, String> metadata = new Hashtable<String, String>();
+        ConcurrentHashMap<String, String> metadata = new ConcurrentHashMap<String, String>();
         metadata.put(HttpEventCollectorSender.MetadataHostTag, host != null ? host : "");
         metadata.put(HttpEventCollectorSender.MetadataIndexTag, index != null ? index : "");
         metadata.put(HttpEventCollectorSender.MetadataSourceTag, source != null ? source : "");

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -20,9 +20,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.Layout;
 
-import java.util.Collections;
-import java.util.Dictionary;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Logback Appender which writes its events to Splunk http event collector rest endpoint.
@@ -59,7 +57,7 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
             return;
 
         // init events sender
-        Dictionary<String, String> metadata = new Hashtable<String, String>();
+        ConcurrentHashMap<String, String> metadata = new ConcurrentHashMap<String, String>();
         if (_host != null)
             metadata.put(HttpEventCollectorSender.MetadataHostTag, _host);
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
@@ -80,9 +80,8 @@ package com.splunk.logging;
  * com.splunk.logging.HttpEventCollectorLoggingHandler.send_mode=sequential
  */
 
-import java.util.Dictionary;
-import java.util.Hashtable;
 import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
@@ -113,7 +112,7 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
     /** HttpEventCollectorLoggingHandler c-or */
     public HttpEventCollectorLoggingHandler() {
         // read configuration settings
-        Dictionary<String, String> metadata = new Hashtable<String, String>();
+        ConcurrentHashMap<String, String> metadata = new ConcurrentHashMap<String, String>();
         metadata.put(HttpEventCollectorSender.MetadataHostTag,
                 getConfigurationProperty(HttpEventCollectorSender.MetadataHostTag, ""));
 

--- a/src/test/java/HttpEventCollectorUnitTest.java
+++ b/src/test/java/HttpEventCollectorUnitTest.java
@@ -17,21 +17,16 @@
  */
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.rmi.runtime.Log;
 
 import java.io.ByteArrayInputStream;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 public class HttpEventCollectorUnitTest {
     @Test

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -19,6 +19,7 @@ import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import com.splunk.*;
 
+import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.junit.Assert;
@@ -26,7 +27,6 @@ import org.slf4j.*;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.logging.LogManager;
@@ -54,7 +54,7 @@ public class TestUtil {
 
             //update serviceArgs with customer splunk host info
             String splunkhostfile = System.getProperty("user.home") + File.separator + ".splunkrc";
-            List<String> lines = Files.readAllLines(new File(splunkhostfile).toPath(), Charset.defaultCharset());
+            List<String> lines = FileUtils.readLines(new File(splunkhostfile), Charset.defaultCharset());
             for (String line : lines) {
                 if (line.toLowerCase().contains("host=")) {
                     serviceArgs.setHost(line.split("=")[1]);
@@ -234,7 +234,7 @@ public class TestUtil {
         getSplunkHostInfo();
 
         String configFileDir = TestUtil.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-        List<String> lines = Files.readAllLines(new File(configFileDir, configFileTemplate).toPath(), Charset.defaultCharset());
+        List<String> lines = FileUtils.readLines(new File(configFileDir, configFileTemplate), Charset.defaultCharset());
         for (int i = 0; i < lines.size(); i++) {
             if (lines.get(i).contains("%host%")) {
                 lines.set(i, lines.get(i).replace("%host%", serviceArgs.host));


### PR DESCRIPTION
No need to synchronize access to metadata map but ConcurrentHashMap should be faster than Hashtable. 

Also fixed test to be compatible with Java6 and switch gson scope to test.