### PR TITLE
Avoid exporting optional modules to dependent project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,12 +220,14 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,17 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- json-simple-1.1.1 from splunk-java-logging does not define scope test -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Avoid exporting junit in scope test (from json-simple)
Avoid exporting log4j to projects using other logging frameworks, e.g. logback