### PR TITLE
Closing httpclient properly on logback shutdown

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -205,8 +205,8 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         if (eventsBatch.size() > 0) {
             postEventsAsync(eventsBatch, close);
         } else if (close) {
-                this.stopHttpClient();
-            }
+            this.stopHttpClient();
+        }
         // Clear the batch. A new list should be created because events are
         // sending asynchronously and "previous" instance of eventsBatch object
         // is still in use.

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -204,7 +204,9 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     public synchronized void flush(boolean close) {
         if (eventsBatch.size() > 0) {
             postEventsAsync(eventsBatch, close);
-        }
+        } else if (close) {
+                this.stopHttpClient();
+            }
         // Clear the batch. A new list should be created because events are
         // sending asynchronously and "previous" instance of eventsBatch object
         // is still in use.


### PR DESCRIPTION
Code at present only closes httpclient, if `eventsBatch.size() > 0`.

But there might be scenarios where logback calls shutdown and there are no events to flush. Therefore `sender.stopHttpClient()` never being called preventing a main method exit due to non-deamon thread usage of httpClient.