### PR TITLE
Remove unnecessary path in test log4j2 config

### DIFF
--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -33,7 +33,7 @@ under the License.
         </Socket>
         
         <SplunkHttp name="http-input"
-              url="http://localhost:5555/services/collector/event/1.0"
+              url="http://localhost:5555"
               token="11111111-2222-3333-4444-555555555555"
               host=""
               index=""


### PR DESCRIPTION
This value is unused but is poor documentation.
Raised by #104 