### PR TITLE
Build `httpClient` with `useSystemProperties`

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -307,6 +307,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
                 sslContext = SSLContexts.custom().loadTrustMaterial(
                         null, acceptingTrustStrategy).build();
                 httpClient = HttpAsyncClients.custom()
+                        .useSystemProperties()
                         .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
                         .setMaxConnTotal(maxConnTotal)
                         .setHostnameVerifier(SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)


### PR DESCRIPTION
This allows us to configure the clients proxy settings using JAVA_OPTS.
Without this there's no way to configure these settings.