### PR TITLE
Resend middleware should always delegate on complete

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorResendMiddleware.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorResendMiddleware.java
@@ -66,10 +66,8 @@ public class HttpEventCollectorResendMiddleware
 
         @Override
         public void completed(int statusCode, final String reply) {
-            if (statusCode != 200) {
-                // resend wouldn't help - report error
-                prevCallback.failed(new HttpEventCollectorErrorHandler.ServerErrorException(reply));
-            }
+            // if non-200, resend wouldn't help, delegate to previous callback
+            prevCallback.completed(statusCode, reply);
         }
 
         @Override


### PR DESCRIPTION
When the resend middleware is added, the previous callback is never invoked on successful (status code 200) completion.  With the default middleware, HttpEventCollectorSender, this means the http client will never get closed if there is anything in the batch when the appender is stopped.  However, with custom middleware that relies on complete or failure to always be invoked, this is much worse and makes the resend middleware unusable.