### PR TITLE
Changing log4j depependencies to "provided" scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,12 +209,14 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.10.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.10.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
These dependencies are needed in this project to test HEC communication through appenders in different logging frameworks. However, they are not needed at runtime, and in fact are expected to be provided by the consuming app. This change reduces the footprint of the consuming apps by not including log4j as a transitive dependency.

This commit resolves issue #103.