### PR TITLE
Allow an HTTP proxy to be configured

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -19,8 +19,8 @@ import ch.qos.logback.classic.pattern.MarkerConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.Layout;
+import org.apache.http.HttpHost;
 
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -52,6 +52,8 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
     private long _batchSize = 0;
     private String _sendMode;
     private long _retriesOnError = 0;
+    private String _httpProxyHost;
+    private int _httpProxyPort;
 
     @Override
     public void start() {
@@ -75,8 +77,14 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
         if (_messageFormat != null)
             metadata.put(HttpEventCollectorSender.MetadataMessageFormatTag, _messageFormat);
 
+        // create proxy host if required
+        HttpHost proxyHost = null;
+        if (_httpProxyHost != null && !_httpProxyHost.isEmpty() && _httpProxyPort != 0) {
+            proxyHost = new HttpHost(_httpProxyHost, _httpProxyPort);
+        }
+
         this.sender = new HttpEventCollectorSender(
-                _url, _token, _channel, _type, _batchInterval, _batchCount, _batchSize, _sendMode, metadata);
+                _url, _token, _channel, _type, _batchInterval, _batchCount, _batchSize, _sendMode, metadata, proxyHost);
 
         // plug a user middleware
         if (_middleware != null && !_middleware.isEmpty()) {
@@ -303,6 +311,10 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
     public void setEventBodySerializer(String eventBodySerializer) {
         this._eventBodySerializer = eventBodySerializer;
     }
+
+    public void setHttpProxyHost(String httpProxyHost) { this._httpProxyHost = httpProxyHost; }
+
+    public void setHttpProxyPort(int httpProxyPort) { this._httpProxyPort = httpProxyPort; }
 
     private static long parseLong(String string, int defaultValue) {
         try {

--- a/src/test/java/HttpEventCollectorUnitTest.java
+++ b/src/test/java/HttpEventCollectorUnitTest.java
@@ -17,21 +17,20 @@
  */
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.rmi.runtime.Log;
 
 import java.io.ByteArrayInputStream;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 public class HttpEventCollectorUnitTest {
     @Test
@@ -44,6 +43,8 @@ public class HttpEventCollectorUnitTest {
         userInputs.put("user_batch_size_count", "1");
         userInputs.put("user_batch_size_bytes", "0");
         userInputs.put("user_eventBodySerializer", "DoesNotExistButShouldNotCrashTest");
+        userInputs.put("user_httpProxyHost", "example.com");
+        userInputs.put("user_httpProxyPort", "5000");
         TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
         org.apache.logging.log4j.Logger LOG4J = org.apache.logging.log4j.LogManager.getLogger(loggerName);
 
@@ -73,6 +74,8 @@ public class HttpEventCollectorUnitTest {
         userInputs.put("user_httpEventCollector_token", "11111111-2222-3333-4444-555555555555");
         userInputs.put("user_middleware", "HttpEventCollectorUnitTestMiddleware");
         userInputs.put("user_eventBodySerializer", "DoesNotExistButShouldNotCrashTest");
+        userInputs.put("user_httpProxyHost", "example.com");
+        userInputs.put("user_httpProxyPort", "5000");
         TestUtil.resetLogbackConfiguration("logback_template.xml", "logback.xml", userInputs);
         org.slf4j.Logger LOGBACK = org.slf4j.LoggerFactory.getLogger(loggerName);
 
@@ -104,7 +107,9 @@ public class HttpEventCollectorUnitTest {
             "com.splunk.logging.HttpEventCollectorLoggingHandler.batch_size_bytes=0\n" +
             "com.splunk.logging.HttpEventCollectorLoggingHandler.batch_interval=0\n" +
             "com.splunk.logging.HttpEventCollectorLoggingHandler.middleware=HttpEventCollectorUnitTestMiddleware\n" +
-            "com.splunk.logging.HttpEventCollectorLoggingHandler.eventBodySerializer=DoesNotExistButShouldNotCrashTest\n"
+            "com.splunk.logging.HttpEventCollectorLoggingHandler.eventBodySerializer=DoesNotExistButShouldNotCrashTest\n" +
+            "com.splunk.logging.HttpEventCollectorLoggingHandler.httpProxyHost=example.com\n" +
+            "com.splunk.logging.HttpEventCollectorLoggingHandler.httpProxyPort=5000\n"
         );
 
         // send 3 events

--- a/src/test/resources/log4j2_template.xml
+++ b/src/test/resources/log4j2_template.xml
@@ -17,6 +17,8 @@
               send_mode="%user_send_mode%"
               middleware="%user_middleware%"
               eventBodySerializer="%user_eventBodySerializer%"
+              httpProxyHost="%user_httpProxyHost%"
+              httpProxyPort="%user_httpProxyPort%"
                 >
 
             <PatternLayout pattern="%m"/>

--- a/src/test/resources/logback_template.xml
+++ b/src/test/resources/logback_template.xml
@@ -18,6 +18,8 @@
         <send_mode>%user_send_mode%</send_mode>
         <middleware>%user_middleware%</middleware>
         <eventBodySerializer>%user_eventBodySerializer%</eventBodySerializer>
+        <httpProxyHost>%user_httpProxyHost%</httpProxyHost>
+        <httpProxyPort>%user_httpProxyPort%</httpProxyPort>
 
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%msg</pattern>


### PR DESCRIPTION
`HttpEventCollectorSender` uses an Apache `CloseableHttpAsyncClient` for
making http requests. The client doesn't respect the `http.proxyHost` and 
`http.proxyPort` system properties. This commit allows configuration for an 
http proxy to be passed to the client via the appenders/handler.