### PR TITLE
only add THROWABLE_STACKTRACE_ELEMENTS field if stacktraceDepth is gr…

### DIFF
--- a/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
+++ b/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
@@ -114,7 +114,9 @@ public class SplunkCimLogEvent {
             sb.append(elements[depth].toString());
         }
 
-        addField(THROWABLE_STACKTRACE_ELEMENTS, sb.toString());
+        if (stacktraceDepth > 0) {
+            addField(THROWABLE_STACKTRACE_ELEMENTS, sb.toString());
+        }
     }
 
     private static final Pattern DOUBLE_QUOTE = Pattern.compile("\"");


### PR DESCRIPTION
If the user doesn't want the stack trace to be part of the event log line, he can set the stacktraceDepth to zero.