### PR TITLE
use null-safe string conversion

### DIFF
--- a/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
+++ b/src/main/java/com/splunk/logging/SplunkCimLogEvent.java
@@ -131,7 +131,7 @@ public class SplunkCimLogEvent {
             } else {
                 first = false;
             }
-            String value = entries.get(key).toString();
+            String value = String.valueOf(entries.get(key));
 
             // Escape any " that appear in the key or value.
             key = DOUBLE_QUOTE.matcher(key).replaceAll("\\\\\"");


### PR DESCRIPTION
Allows field values to be null. This is required if an exception with a null message is added using addThrowableWithStacktrace but may be useful in general.