### PR TITLE
Replacing the CloseableHttpAsyncClient with a shared OkHttpClient 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.12.2</version>
+            <version>3.14.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,19 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,14 +29,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.1</version>
-                        <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>biz.aQute.bnd</groupId>
                         <artifactId>bnd-maven-plugin</artifactId>
                         <version>3.5.0</version>
@@ -129,14 +121,6 @@
             <id>StressTest</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.1</version>
-                        <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -194,15 +194,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpasyncclient</artifactId>
-            <version>4.1.3</version>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.12.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
+            <version>3.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.Filter;
@@ -208,8 +209,8 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
     }
 
     @Override
-    public void stop() {
+    public boolean stop(long timeout, TimeUnit timeUnit) {
         this.sender.close();
-        super.stop();
+        return super.stop(timeout, timeUnit);
     }
 }

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -26,12 +26,7 @@ import javax.net.ssl.*;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.cert.CertificateException;
-import java.util.Dictionary;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.List;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 
 
 /**

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -192,6 +192,9 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
 
     @Deprecated
     public synchronized void flush(boolean close) {
+        if (close) {
+            stopHttpClient();
+        }
         flush();
     }
 
@@ -202,6 +205,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         if (timer != null)
             timer.cancel();
         flush();
+        stopHttpClient();
         super.cancel();
     }
 
@@ -259,6 +263,13 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
 
         event.put("event", eventBodySerializer.serializeEventBody(eventInfo, parsedMessage));
         return event.toString();
+    }
+
+    private void stopHttpClient() {
+        if (httpClient != null) {
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient = null;
+        }
     }
 
     private void startHttpClient() {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -301,7 +301,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
 
             try {
                 // install the all-trusting trust manager
-                final SSLContext sslContext = SSLContext.getInstance("SSL");
+                final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
                 sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
                 // create an ssl socket factory with the all-trusting manager
                 final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -272,7 +272,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         // limit max  number of async requests in sequential mode
         if (sendMode == SendMode.Sequential) {
             Dispatcher dispatcher = new Dispatcher();
-            dispatcher.setMaxRequestsPerHost(1);
+            dispatcher.setMaxRequests(1);
             builder.dispatcher(dispatcher);
         }
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -190,12 +190,11 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         eventsBatchSize = 0;
     }
 
-    @Deprecated
     public synchronized void flush(boolean close) {
+        flush();
         if (close) {
             stopHttpClient();
         }
-        flush();
     }
 
     /**

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -18,33 +18,20 @@ package com.splunk.logging;
  * under the License.
  */
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.concurrent.FutureCallback;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.SSLContexts;
-import org.apache.http.conn.ssl.TrustStrategy;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
-import org.apache.http.util.EntityUtils;
+import okhttp3.*;
 
 import org.json.simple.JSONObject;
 
-import javax.net.ssl.SSLContext;
+import javax.net.ssl.*;
 import java.io.IOException;
 import java.io.Serializable;
-import java.security.cert.X509Certificate;
+import java.security.cert.CertificateException;
 import java.util.Dictionary;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.Locale;
-
 
 
 /**
@@ -94,7 +81,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     private Timer timer;
     private List<HttpEventCollectorEventInfo> eventsBatch = new LinkedList<HttpEventCollectorEventInfo>();
     private long eventsBatchSize = 0; // estimated total size of events batch
-    private CloseableHttpAsyncClient httpClient;
+    private static OkHttpClient httpClient = null;
     private boolean disableCertificateValidation = false;
     private SendMode sendMode = SendMode.Sequential;
     private HttpEventCollectorMiddleware middleware = new HttpEventCollectorMiddleware();
@@ -198,20 +185,19 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
      * Flush all pending events
      */
     public synchronized void flush() {
-        flush(false);
-    }
-
-    public synchronized void flush(boolean close) {
         if (eventsBatch.size() > 0) {
-            postEventsAsync(eventsBatch, close);
-        } else if (close) {
-            this.stopHttpClient();
+            postEventsAsync(eventsBatch);
         }
         // Clear the batch. A new list should be created because events are
         // sending asynchronously and "previous" instance of eventsBatch object
         // is still in use.
         eventsBatch = new LinkedList<HttpEventCollectorEventInfo>();
         eventsBatchSize = 0;
+    }
+
+    @Deprecated
+    public synchronized void flush(boolean close) {
+        flush();
     }
 
     /**
@@ -285,56 +271,55 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             // http client is already started
             return;
         }
-        // limit max  number of async requests in sequential mode, 0 means "use
-        // default limit"
-        int maxConnTotal = sendMode == SendMode.Sequential ? 1 : 0;
-        if (! disableCertificateValidation) {
-            // create an http client that validates certificates
-            httpClient = HttpAsyncClients.custom()
-                    .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
-                    .useSystemProperties()
-                    .setMaxConnTotal(maxConnTotal)
-                    .build();
-        } else {
-            // create strategy that accepts all certificates
-            TrustStrategy acceptingTrustStrategy = new TrustStrategy() {
-                public boolean isTrusted(X509Certificate[] certificate,
-                                         String type) {
+
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+        // limit max  number of async requests in sequential mode
+        if (sendMode == SendMode.Sequential) {
+            Dispatcher dispatcher = new Dispatcher();
+            dispatcher.setMaxRequestsPerHost(1);
+            builder.dispatcher(dispatcher);
+        }
+
+        if (disableCertificateValidation) {
+            final TrustManager[] trustAllCerts = new TrustManager[]{
+                    new X509TrustManager() {
+                        @Override
+                        public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                        }
+
+                        @Override
+                        public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                        }
+
+                        @Override
+                        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                            return new java.security.cert.X509Certificate[]{};
+                        }
+                    }
+            };
+
+            try {
+                // install the all-trusting trust manager
+                final SSLContext sslContext = SSLContext.getInstance("SSL");
+                sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+                // create an ssl socket factory with the all-trusting manager
+                final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+                builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0]);
+            } catch (Exception ignored) { /* nop */ }
+
+            builder.hostnameVerifier(new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
                     return true;
                 }
-            };
-            SSLContext sslContext = null;
-            try {
-                sslContext = SSLContexts.custom().loadTrustMaterial(
-                        null, acceptingTrustStrategy).build();
-                httpClient = HttpAsyncClients.custom()
-                        .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
-                        .setMaxConnTotal(maxConnTotal)
-                        .setHostnameVerifier(SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)
-                        .setSSLContext(sslContext)
-                        .build();
-            } catch (Exception e) { }
+            });
         }
-        httpClient.start();
-    }
 
-    // Currently we never close http client. This method is added for symmetry
-    // with startHttpClient.
-    private void stopHttpClient() throws SecurityException {
-        if (httpClient != null) {
-            try {
-                httpClient.close();
-            } catch (IOException e) { }
-            httpClient = null;
-        }
+        httpClient = builder.build();
     }
 
     private void postEventsAsync(final List<HttpEventCollectorEventInfo> events) {
-        postEventsAsync(events, false);
-    }
-
-    private void postEventsAsync(final List<HttpEventCollectorEventInfo> events, final boolean close) {
-        final HttpEventCollectorSender sender = this;
         this.middleware.postEvents(events,  this, new HttpEventCollectorMiddleware.IHttpSenderCallback() {
 
             @Override
@@ -344,9 +329,6 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
                             events,
                             new HttpEventCollectorErrorHandler.ServerErrorException(reply));
                 }
-                if (close) {
-                    sender.stopHttpClient();
-                }
             }
 
             @Override
@@ -354,9 +336,6 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
                 HttpEventCollectorErrorHandler.error(
                         events,
                         new HttpEventCollectorErrorHandler.ServerErrorException(ex.getMessage()));
-                if (close) {
-                    sender.stopHttpClient();
-                }
             }
         });
     }
@@ -364,31 +343,29 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     public void postEvents(final List<HttpEventCollectorEventInfo> events,
                            final HttpEventCollectorMiddleware.IHttpSenderCallback callback) {
         startHttpClient(); // make sure http client is started
-        final String encoding = "utf-8";
         // convert events list into a string
         StringBuilder eventsBatchString = new StringBuilder();
         for (HttpEventCollectorEventInfo eventInfo : events)
             eventsBatchString.append(serializeEventInfo(eventInfo));
         // create http request
-        final HttpPost httpPost = new HttpPost(url);
-        httpPost.setHeader(
-                AuthorizationHeaderTag,
-                String.format(AuthorizationHeaderScheme, token));
+        Request.Builder requestBldr = new Request.Builder()
+                .url(url)
+                .addHeader(AuthorizationHeaderTag, String.format(AuthorizationHeaderScheme, token))
+                .post(RequestBody.create(MediaType.parse(HttpContentType), eventsBatchString.toString()));
+
         if ("Raw".equalsIgnoreCase(type) && channel != null && !channel.trim().equals("")) {
-            httpPost.setHeader(SPLUNKREQUESTCHANNELTag, channel);
+            requestBldr.addHeader(SPLUNKREQUESTCHANNELTag, channel);
         }
-        StringEntity entity = new StringEntity(eventsBatchString.toString(), encoding);
-        entity.setContentType(HttpContentType);
-        httpPost.setEntity(entity);
-        httpClient.execute(httpPost, new FutureCallback<HttpResponse>() {
+
+        httpClient.newCall(requestBldr.build()).enqueue(new Callback() {
             @Override
-            public void completed(HttpResponse response) {
+            public void onResponse(Call call, final Response response) {
                 String reply = "";
-                int httpStatusCode = response.getStatusLine().getStatusCode();
+                int httpStatusCode = response.code();
                 // read reply only in case of a server error
-                if (httpStatusCode != 200) {
+                if (httpStatusCode != 200 && response.body() != null) {
                     try {
-                        reply = EntityUtils.toString(response.getEntity(), encoding);
+                        reply = response.body().string();
                     } catch (IOException e) {
                         reply = e.getMessage();
                     }
@@ -397,12 +374,9 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             }
 
             @Override
-            public void failed(Exception ex) {
+            public void onFailure(Call call, IOException ex) {
                 callback.failed(ex);
             }
-
-            @Override
-            public void cancelled() {}
         });
     }
 }

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -206,7 +206,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     void close() {
         if (timer != null)
             timer.cancel();
-        flush(true);
+        flush();
         super.cancel();
     }
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -363,11 +363,13 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
                 String reply = "";
                 int httpStatusCode = response.code();
                 // read reply only in case of a server error
-                if (httpStatusCode != 200 && response.body() != null) {
-                    try {
-                        reply = response.body().string();
-                    } catch (IOException e) {
-                        reply = e.getMessage();
+                try (ResponseBody body = response.body()) {
+                    if (httpStatusCode != 200 && body != null) {
+                        try {
+                            reply = body.string();
+                        } catch (IOException e) {
+                            reply = e.getMessage();
+                        }
                     }
                 }
                 callback.completed(httpStatusCode, reply);

--- a/src/test/java/HttpEventCollector_JavaLoggingTest.java
+++ b/src/test/java/HttpEventCollector_JavaLoggingTest.java
@@ -343,7 +343,7 @@ public final class HttpEventCollector_JavaLoggingTest {
         Assert.assertEquals(1, errors.size());
 
         System.out.println(logEx.toString());
-        if (!(logEx.toString().contains("Connection refused") || logEx.toString().contains("Connection closed")))
+        if (!(logEx.toString().contains("Failed to connect to")))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 

--- a/src/test/java/HttpEventCollector_JavaLoggingTest.java
+++ b/src/test/java/HttpEventCollector_JavaLoggingTest.java
@@ -21,6 +21,7 @@ import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 
 import com.splunk.logging.HttpEventCollectorSender;
+import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -343,7 +344,7 @@ public final class HttpEventCollector_JavaLoggingTest {
         Assert.assertEquals(1, errors.size());
 
         System.out.println(logEx.toString());
-        if (!(logEx.toString().contains("Failed to connect to")))
+        if (!StringUtils.containsAny(logEx.toString(), "Failed to connect to", "Remote host terminated the handshake", "Connection reset"))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -20,6 +20,7 @@ import java.util.*;
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
@@ -328,7 +329,7 @@ public final class HttpEventCollector_Log4j2Test {
         Assert.assertTrue(errors.size() >= 1);
 
         System.out.println(logEx.toString());
-        if (!(logEx.toString().contains("Failed to connect to")))
+        if (!StringUtils.containsAny(logEx.toString(), "Failed to connect to", "Remote host terminated the handshake", "Connection reset"))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -328,7 +328,7 @@ public final class HttpEventCollector_Log4j2Test {
         Assert.assertTrue(errors.size() >= 1);
 
         System.out.println(logEx.toString());
-        if (!(logEx.toString().contains("Connection refused") || logEx.toString().contains("Connection closed")))
+        if (!(logEx.toString().contains("Failed to connect to")))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 

--- a/src/test/java/HttpEventCollector_LogbackTest.java
+++ b/src/test/java/HttpEventCollector_LogbackTest.java
@@ -320,7 +320,7 @@ public final class HttpEventCollector_LogbackTest {
         Assert.assertEquals(1, errors.size());
 
         System.out.println(logEx.toString());
-        if (!(logEx.toString().contains("Connection refused") || logEx.toString().contains("Connection closed")))
+        if (!(logEx.toString().contains("Failed to connect to")))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 

--- a/src/test/java/HttpEventCollector_LogbackTest.java
+++ b/src/test/java/HttpEventCollector_LogbackTest.java
@@ -19,6 +19,7 @@ import java.util.*;
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -320,7 +321,7 @@ public final class HttpEventCollector_LogbackTest {
         Assert.assertEquals(1, errors.size());
 
         System.out.println(logEx.toString());
-        if (!(logEx.toString().contains("Failed to connect to")))
+        if (!StringUtils.containsAny(logEx.toString(), "Failed to connect to", "Remote host terminated the handshake", "Connection reset"))
             Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
     }
 


### PR DESCRIPTION
We encountered a massive resource usage overhead caused by multiple Splunk Log4J appenders in one application. Similar observations were also mentioned in #128, #66 and #115. A root cause of the overhead are `I/O Dsipatcher` threads created by multiple `CloseableHttpAsyncClient`s. Furthermore these threads are never terminated, even if they are idle for a long time.

Our proposed solution uses a single instance of the `OkHttpClient` to reduce overhead. Additionally, a shutdown mechanism is no longer required, as the threads are automatically released if they remain idle.