### PR TITLE
Facilitate multiple appenders with heterogeneous HTTP configurations

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -77,7 +77,8 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     private Timer timer;
     private List<HttpEventCollectorEventInfo> eventsBatch = new LinkedList<HttpEventCollectorEventInfo>();
     private long eventsBatchSize = 0; // estimated total size of events batch
-    private static OkHttpClient httpClient = null;
+    private static final OkHttpClient httpSharedClient = new OkHttpClient(); // shared instance with the default settings
+    private OkHttpClient httpClient = null; // shares the same connection pool and thread pools with the shared instance
     private boolean disableCertificateValidation = false;
     private SendMode sendMode = SendMode.Sequential;
     private HttpEventCollectorMiddleware middleware = new HttpEventCollectorMiddleware();
@@ -252,7 +253,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             return;
         }
 
-        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        OkHttpClient.Builder builder = httpSharedClient.newBuilder();
 
         // limit max  number of async requests in sequential mode
         if (sendMode == SendMode.Sequential) {


### PR DESCRIPTION
Dear HEC lovers,
We encountered an undefined behavior of the HEC forwarder when using appenders with both sequential and parallel send mode. The problem is related to the use of a single shared HTTP client because the HTTP configuration of the first appender is overwritten when the second appender is created. However, the `OkHttpClient` supports to share only the resources (e.g. connection pool, thread pools) but not the configuration.

Cheers,
Norwin