### PR TITLE
Added ability to set awaitTermination timeout and time unit

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -187,7 +187,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
         return new HttpEventCollectorLog4jAppender(
                 name, url, token,  channel, type,
                 source, sourcetype, messageFormat,
-                parseInt(awaitTerminationTimeout, HttpEventCollectorSender.DefaultAwaitTerminationTimeUnit),
+                parseInt(awaitTerminationTimeout, HttpEventCollectorSender.DefaultAwaitTerminationTimeout),
                 awaitTerminationTimeUnit,
                 host, index,
                 filter, layout, 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -15,24 +15,23 @@ package com.splunk.logging;
  * under the License.
  */
 
-import java.io.Serializable;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import com.splunk.logging.hec.MetadataTags;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Splunk Http Appender.
@@ -56,6 +55,8 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
                          final String source,
                          final String sourcetype,
                          final String messageFormat,
+                         final long awaitTerminationTimeout,
+                         final String awaitTerminationTimeUnit,
                          final String host,
                          final String index,
                          final Filter filter,
@@ -82,6 +83,8 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
         metadata.put(MetadataTags.SOURCE, source != null ? source : "");
         metadata.put(MetadataTags.SOURCETYPE, sourcetype != null ? sourcetype : "");
         metadata.put(MetadataTags.MESSAGEFORMAT, messageFormat != null ? messageFormat : "");
+        metadata.put(MetadataTags.AWAITTERMINATIONTIMEOUT, Long.toString(awaitTerminationTimeout));
+        metadata.put(MetadataTags.AWAITTERMINATIONTIMEUNIT, awaitTerminationTimeUnit != null ? awaitTerminationTimeUnit : "SECONDS");
 
         this.sender = new HttpEventCollectorSender(url, token, channel, type, batchInterval, batchCount, batchSize, sendMode, metadata);
 
@@ -129,6 +132,8 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
             @PluginAttribute("source") final String source,
             @PluginAttribute("sourcetype") final String sourcetype,
             @PluginAttribute("messageFormat") final String messageFormat,
+            @PluginAttribute("awaitTerminationTimeout") final String awaitTerminationTimeout,
+            @PluginAttribute("awaitTerminationTimeUnit") final String awaitTerminationTimeUnit,
             @PluginAttribute("host") final String host,
             @PluginAttribute("index") final String index,
             @PluginAttribute(value = "ignoreExceptions", defaultBoolean = true) final String ignoreExceptions,
@@ -181,7 +186,10 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
 
         return new HttpEventCollectorLog4jAppender(
                 name, url, token,  channel, type,
-                source, sourcetype, messageFormat, host, index,
+                source, sourcetype, messageFormat,
+                parseInt(awaitTerminationTimeout, HttpEventCollectorSender.DefaultAwaitTerminationTimeUnit),
+                awaitTerminationTimeUnit,
+                host, index,
                 filter, layout, 
                 includeLoggerName, includeThreadName, includeMDC, includeException, includeMarker,
                 ignoreExceptionsBool,

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -21,7 +21,8 @@ import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.Layout;
 import com.splunk.logging.hec.MetadataTags;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Logback Appender which writes its events to Splunk http event collector rest endpoint.
@@ -37,6 +38,8 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
     private String _source;
     private String _sourcetype;
     private String _messageFormat;
+    private long _awaitTerminationTimeout = 0;
+    private String _awaitTerminationTimeUnit;
     private String _host;
     private String _index;
     private String _url;
@@ -73,6 +76,9 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
         
         if (_messageFormat != null)
             metadata.put(MetadataTags.MESSAGEFORMAT, _messageFormat);
+
+        metadata.put(MetadataTags.AWAITTERMINATIONTIMEOUT, Long.toString(_awaitTerminationTimeout));
+        metadata.put(MetadataTags.AWAITTERMINATIONTIMEUNIT, _awaitTerminationTimeUnit != null ? _awaitTerminationTimeUnit : "SECONDS");
 
         this.sender = new HttpEventCollectorSender(
                 _url, _token, _channel, _type, _batchInterval, _batchCount, _batchSize, _sendMode, metadata);

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
@@ -82,7 +82,9 @@ package com.splunk.logging;
 
 import com.splunk.logging.hec.MetadataTags;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
@@ -125,10 +127,16 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
 
         metadata.put(MetadataTags.SOURCETYPE,
                 getConfigurationProperty(MetadataTags.SOURCETYPE, ""));
-        
+
         // Extract message format value
         metadata.put(MetadataTags.MESSAGEFORMAT,
-            getConfigurationProperty(MetadataTags.MESSAGEFORMAT, ""));
+                getConfigurationProperty(MetadataTags.MESSAGEFORMAT, ""));
+
+        metadata.put(MetadataTags.AWAITTERMINATIONTIMEOUT,
+                getConfigurationProperty(MetadataTags.AWAITTERMINATIONTIMEOUT, "0"));
+
+        metadata.put(MetadataTags.AWAITTERMINATIONTIMEUNIT,
+                getConfigurationProperty(MetadataTags.AWAITTERMINATIONTIMEUNIT, "SECONDS"));
 
         // http event collector endpoint properties
         String url = getConfigurationProperty(UrlConfTag, null);

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -70,7 +70,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     public static final int DefaultBatchInterval = 10 * 1000; // 10 seconds
     public static final int DefaultBatchSize = 10 * 1024; // 10KB
     public static final int DefaultBatchCount = 10; // 10 events
-    public static final int DefaultAwaitTerminationTimeUnit = 0;
+    public static final int DefaultAwaitTerminationTimeout = 0;
 
     private String url;
     private String token;

--- a/src/main/java/com/splunk/logging/hec/MetadataTags.java
+++ b/src/main/java/com/splunk/logging/hec/MetadataTags.java
@@ -5,10 +5,9 @@
  */
 package com.splunk.logging.hec;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class MetadataTags {
     public static final String TIME = "time";
@@ -17,8 +16,10 @@ public class MetadataTags {
     public static final String SOURCE = "source";
     public static final String SOURCETYPE = "sourcetype";
     public static final String MESSAGEFORMAT = "messageFormat";
-    public static final Set<String> HEC_TAGS =
-            new HashSet<>(Arrays.asList(TIME, HOST, INDEX, SOURCE, SOURCETYPE));
-    public static final Set<String> INTERNAL_TAGS=
-            new HashSet<>(Collections.singletonList(MESSAGEFORMAT));
+    public static final String AWAITTERMINATIONTIMEOUT = "awaitTerminationTimeout";
+    public static final String AWAITTERMINATIONTIMEUNIT = "awaitTerminationTimeUnit";
+    public static final Set<String> HEC_TAGS = Stream.of(TIME, HOST, INDEX, SOURCE, SOURCETYPE)
+            .collect(Collectors.toSet());
+    public static final Set<String> INTERNAL_TAGS = Stream.of(MESSAGEFORMAT, AWAITTERMINATIONTIMEOUT, AWAITTERMINATIONTIMEUNIT)
+            .collect(Collectors.toSet());
 }


### PR DESCRIPTION
When running in a docker container or lambda, the logs are not
completing being sent because the instance or container is being
killed prior to shutdown completing.