### PR TITLE
Remove duplicate send_mode element in template

### DIFF
--- a/src/test/resources/logback_template.xml
+++ b/src/test/resources/logback_template.xml
@@ -15,7 +15,6 @@
         <batch_size_bytes>%user_batch_size_bytes%</batch_size_bytes>
         <batch_size_count>%user_batch_size_count%</batch_size_count>
         <send_mode>%user_send_mode%</send_mode>
-        <send_mode>%user_send_mode%</send_mode>
         <middleware>%user_middleware%</middleware>
         <eventBodySerializer>%user_eventBodySerializer%</eventBodySerializer>
 


### PR DESCRIPTION
Hi!

Was just using the logback configuration templates as a guide and noticed the redundant element.

Thanks for providing this lib 👍 