### PR TITLE
Pass time with milliseconds precision when custom body serializer is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,14 +162,14 @@
         <repository>
             <id>splunk-artifactory</id>
             <name>Splunk Releases</name>
-            <url>http://splunk.artifactoryonline.com/splunk/ext-releases-local</url>
+            <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
         </repository>
     </repositories>
     <distributionManagement>
         <repository>
             <id>splunk-artifactory</id>
             <name>Splunk Releases</name>
-            <url>http://splunk.artifactoryonline.com/splunk/ext-releases-local</url>
+            <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
         </repository>
     </distributionManagement>
 

--- a/src/main/java/com/splunk/logging/EventBodySerializer.java
+++ b/src/main/java/com/splunk/logging/EventBodySerializer.java
@@ -5,6 +5,8 @@ package com.splunk.logging;
  * Define the interface to allow users to define their own event body serializer for HTTP event adapter:
  * Simply create a class implementing this interface, and add the full class name as a property (`eventBodySerializer`) to the adapter.
  *
+ * @see com.splunk.logging.serialization.PlainTextEventBodySerializer
+ *
 */
 public interface EventBodySerializer {
 
@@ -12,4 +14,12 @@ public interface EventBodySerializer {
             HttpEventCollectorEventInfo eventInfo,
             Object formattedMessage
     );
+
+    /**
+     * Timestamp to be sent with custom message.
+     * @return 0 if do not want to send timestamp with message, otherwise number of seconds, between the current time and midnight, January 1, 1970 UTC.
+     */
+    default double getEventTime(HttpEventCollectorEventInfo eventInfo) {
+        return 0;
+    }
 }

--- a/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
+++ b/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
@@ -48,6 +48,9 @@ public class HecJsonSerializer {
         Map<String, Object> event = new HashMap<>(template);
         if (this.eventBodySerializer != null) {
             event.put("event", eventBodySerializer.serializeEventBody(info, info.getMessage()));
+            if (info.getTime() > 0) {
+                event.put("time", String.format(Locale.US, "%.3f", info.getTime()));
+            }
         } else {
             event.put("event", info);
         }

--- a/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
+++ b/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
@@ -48,8 +48,9 @@ public class HecJsonSerializer {
         Map<String, Object> event = new HashMap<>(template);
         if (this.eventBodySerializer != null) {
             event.put("event", eventBodySerializer.serializeEventBody(info, info.getMessage()));
-            if (info.getTime() > 0) {
-                event.put("time", String.format(Locale.US, "%.3f", info.getTime()));
+            double eventTime = eventBodySerializer.getEventTime(info);
+            if (eventTime > 0) {
+                event.put("time", String.format(Locale.US, "%.3f", eventTime));
             }
         } else {
             event.put("event", info);

--- a/src/main/java/com/splunk/logging/serialization/PlainTextEventBodySerializer.java
+++ b/src/main/java/com/splunk/logging/serialization/PlainTextEventBodySerializer.java
@@ -1,0 +1,21 @@
+package com.splunk.logging.serialization;
+
+import com.splunk.logging.EventBodySerializer;
+import com.splunk.logging.HttpEventCollectorEventInfo;
+
+/**
+ * Custom serializer which send message in plain-text format and provides message timestamp with millisecond precision.
+ */
+public class PlainTextEventBodySerializer implements EventBodySerializer {
+
+	@Override
+	public String serializeEventBody(HttpEventCollectorEventInfo eventInfo, Object formattedMessage) {
+		return String.valueOf(formattedMessage);
+	}
+
+	@Override
+	public double getEventTime(HttpEventCollectorEventInfo eventInfo) {
+		return eventInfo.getTime();
+	}
+
+}

--- a/src/main/java/com/splunk/logging/serialization/PlainTextEventBodySerializer.java
+++ b/src/main/java/com/splunk/logging/serialization/PlainTextEventBodySerializer.java
@@ -4,7 +4,7 @@ import com.splunk.logging.EventBodySerializer;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 
 /**
- * Custom serializer which send message in plain-text format and provides message timestamp with millisecond precision.
+ * Custom serializer which sends message in plain-text format and provides message timestamp with millisecond precision.
  */
 public class PlainTextEventBodySerializer implements EventBodySerializer {
 


### PR DESCRIPTION
At the moment, if custom body serializer is used then no time is passed to Splunk server. 

It has two consequences

1. Batch gets the same timestamp on Splunk side
2. Assigned timestamp has seconds precision so events order is corrupted when multiple nodes feed data to Splunk

This PR fixes issue by sending local time with milliseconds precision even if custom body serializer is used