### PR TITLE
Send raw events as text/plain requests

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -104,8 +104,12 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         this.channel = channel;
         this.type = type;
 
-        if ("Raw".equalsIgnoreCase(type) && channel != null && !channel.trim().equals("")) {
-            HttpUrl.Builder urlBuilder = HttpUrl.parse(Url + HttpRawCollectorUriPath).newBuilder()
+        if ("Raw".equalsIgnoreCase(type)) {
+            if (channel == null || channel.trim().equals("")) {
+                throw new IllegalArgumentException("Channel cannot be null or empty");
+            }
+            HttpUrl.Builder urlBuilder = HttpUrl.parse(Url + HttpRawCollectorUriPath)
+                    .newBuilder()
                     .addQueryParameter(ChannelQueryParam, channel);
             metadata.forEach(urlBuilder::addQueryParameter);
             this.url = urlBuilder.build();

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -29,18 +29,20 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.security.cert.CertificateException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 /**
  * This is an internal helper class that sends logging events to Splunk http event collector.
  */
 public class HttpEventCollectorSender extends TimerTask implements HttpEventCollectorMiddleware.IHttpSender {
-    private static final String SPLUNKREQUESTCHANNELTag = "X-Splunk-Request-Channel";
+    private static final String ChannelQueryParam = "channel";
     private static final String AuthorizationHeaderTag = "Authorization";
     private static final String AuthorizationHeaderScheme = "Splunk %s";
     private static final String HttpEventCollectorUriPath = "/services/collector/event/1.0";
     private static final String HttpRawCollectorUriPath = "/services/collector/raw";
-    private static final String HttpContentType = "application/json; profile=urn:splunk:event:1.0; charset=utf-8";
+    private static final String JsonHttpContentType = "application/json; profile=urn:splunk:event:1.0; charset=utf-8";
+    private static final String PlainTextHttpContentType = "plain/text; charset=utf-8";
     private static final String SendModeSequential = "sequential";
     private static final String SendModeSParallel = "parallel";
     private static final Gson gson = new GsonBuilder()
@@ -68,7 +70,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     public static final int DefaultBatchSize = 10 * 1024; // 10KB
     public static final int DefaultBatchCount = 10; // 10 events
 
-    private String url;
+    private HttpUrl url;
     private String token;
     private String channel;
     private String type;
@@ -81,7 +83,6 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     private boolean disableCertificateValidation = false;
     private SendMode sendMode = SendMode.Sequential;
     private HttpEventCollectorMiddleware middleware = new HttpEventCollectorMiddleware();
-    private final MessageFormat messageFormat;
 
     /**
      * Initialize HttpEventCollectorSender
@@ -99,13 +100,17 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             long delay, long maxEventsBatchCount, long maxEventsBatchSize,
             String sendModeStr,
             Map<String, String> metadata) {
-        this.url = Url + HttpEventCollectorUriPath;
         this.token = token;
         this.channel = channel;
         this.type = type;
 
-        if ("Raw".equalsIgnoreCase(type)) {
-            this.url = Url + HttpRawCollectorUriPath;
+        if ("Raw".equalsIgnoreCase(type) && channel != null && !channel.trim().equals("")) {
+            HttpUrl.Builder urlBuilder = HttpUrl.parse(Url + HttpRawCollectorUriPath).newBuilder()
+                    .addQueryParameter(ChannelQueryParam, channel);
+            metadata.forEach(urlBuilder::addQueryParameter);
+            this.url = urlBuilder.build();
+        } else {
+            this.url = HttpUrl.parse(Url + HttpEventCollectorUriPath);
         }
 
         // when size configuration setting is missing it's treated as "infinity",
@@ -122,7 +127,6 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         final String format = metadata.get(MetadataTags.MESSAGEFORMAT);
         // Get MessageFormat enum from format string. Do this once per instance in constructor to avoid expensive operation in
         // each event sender call
-        this.messageFormat = MessageFormat.fromFormat(format);
 
         if (sendModeStr != null) {
             if (sendModeStr.equals(SendModeSequential))
@@ -323,19 +327,22 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     public void postEvents(final List<HttpEventCollectorEventInfo> events,
                            final HttpEventCollectorMiddleware.IHttpSenderCallback callback) {
         startHttpClient(); // make sure http client is started
-        // convert events list into a string
-        StringBuilder eventsBatchString = new StringBuilder();
-        for (HttpEventCollectorEventInfo eventInfo : events) {
-            eventsBatchString.append(serializer.serialize(eventInfo));
-        }
         // create http request
         Request.Builder requestBldr = new Request.Builder()
                 .url(url)
-                .addHeader(AuthorizationHeaderTag, String.format(AuthorizationHeaderScheme, token))
-                .post(RequestBody.create(MediaType.parse(HttpContentType), eventsBatchString.toString()));
-
-        if ("Raw".equalsIgnoreCase(type) && channel != null && !channel.trim().equals("")) {
-            requestBldr.addHeader(SPLUNKREQUESTCHANNELTag, channel);
+                .addHeader(AuthorizationHeaderTag, String.format(AuthorizationHeaderScheme, token));
+        if ("Raw".equalsIgnoreCase(type)) {
+            String lineSeparatedEvents = events.stream()
+                    .map(HttpEventCollectorEventInfo::getMessage)
+                    .collect(Collectors.joining(System.lineSeparator()));
+            requestBldr.post(RequestBody.create(MediaType.parse(PlainTextHttpContentType), lineSeparatedEvents));
+        } else {
+            // convert events list into a string
+            StringBuilder eventsBatchString = new StringBuilder();
+            for (HttpEventCollectorEventInfo eventInfo : events) {
+                eventsBatchString.append(serializer.serialize(eventInfo));
+            }
+            requestBldr.post(RequestBody.create(MediaType.parse(JsonHttpContentType), eventsBatchString.toString()));
         }
 
         httpClient.newCall(requestBldr.build()).enqueue(new Callback() {


### PR DESCRIPTION
Currently, if the `raw` type is set on the `HttpEventCollectorSender`, it only changes the path used for the request and adds the `X-Splunk-Request-Channel` header with the `channel` that's set. The body of the request is still encoded as JSON and Splunk interprets as such.

This pull request changes the request to be line-separated event messages and updates the URL to use query parameters for the channel and metadata when using the `raw` type.