### PR TITLE
Updated the project to use make conventions to spin up a local dockerized instance.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           - "latest"
           - "8.0"
     runs-on: ubuntu-latest
-    container: maven:3-jdk-8
+    #container: maven:3-jdk-8
 
     services:
       splunk:
@@ -69,6 +69,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Acceptance Test
-        uses: ./.github/actions/go-make-action
-        with:
-          target: 'test'
+        run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,28 +4,57 @@ on:
   [push, pull_request]
 
 jobs:
+  unit-test:
+    strategy:
+      matrix:
+        java-version:
+          - 1.8
+          - 11
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Unit Test
+        run: mvn -P Unittest -B verify --file pom.xml
 
-  test-execution:
+  acceptance-test:
+    needs: unit-test
     strategy:
       matrix:
         splunk-version:
-          - "latest"
           - "8.0"
+          - "latest"
     runs-on: ubuntu-latest
+    container: maven:3-jdk-8
+
     services:
       splunk:
         image: splunk/splunk:${{matrix.splunk-version}}
         env:
           SPLUNK_START_ARGS: --accept-license
-          SPLUNK_PASSWORD: changed!
+          SPLUNK_PASSWORD: chamged!
         ports:
-          - 8000:8000
-          - 5555:5555
-          - 8088:8088
-          - 8089:8089
-          - 15000:15000
-          - 10667:10667
-          - 10668:10668/udp
+          - 8089
+          - 8088
+          - 5555
+          - 15000
+          - 10667
+          - 10668/udp
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -39,5 +68,8 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Make Test
-        run: make test
+      - name: Acceptance Test
+        run: mvn -P AcceptanceTest -B verify --file pom.xml
+        env:
+          SPLUNK_PASSWORD: changed!
+          SPLUNK_HOST: splunk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,6 @@ jobs:
     strategy:
       matrix:
         splunk-version:
-          - latest
           - 8.0
     runs-on: ubuntu-latest
     container: maven:3-jdk-8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,14 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Set up make
-        run: apt-get -y install make
-      - name: Make Up
-        run: make up
-      - name: Make Test
-        run: make test
+      - name: Set up docker
+        run: docker-compose up -d
+#      - name: Make Up
+#        run: make up
+      - name: Unit Test
+        run: mvn package -P Unittest
+#      - name: Acceptance Test
+#        run: mvn package -P AcceptanceTest
         env:
           SPLUNK_PASSWORD: changed!
           SPLUNK_HOST: splunk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Set up docker
+        with:
+          file: ./docker-compose.yml
         run: docker-compose up -d
 #      - name: Make Up
 #        run: make up

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Set up make
-        run: sudo apt-get -y install make
+        run: apt-get -y install make
       - name: Make Up
         run: make up
       - name: Make Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     container: maven:3-jdk-8
     steps:
+      - name: Set up make
+      - run: sudo apt-get -y install make
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,34 +4,8 @@ on:
   [push, pull_request]
 
 jobs:
-#  unit-test:
-#    strategy:
-#      matrix:
-#        java-version:
-#          - 1.8
-#          - 11
-#        os:
-#          - ubuntu-latest
-#          - windows-latest
-#          - macos-latest
-#    runs-on: ${{ matrix.os }}
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Set up JDK
-#        uses: actions/setup-java@v1
-#        with:
-#          java-version: ${{ matrix.java-version }}
-#      - name: Cache local Maven repository
-#        uses: actions/cache@v2
-#        with:
-#          path: ~/.m2/repository
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven-
-#      - name: Unit Test
-#        run: mvn -P Unittest -B verify --file pom.xml
 
-  acceptance-test:
+  tests:
 #    needs: unit-test
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         image: splunk/splunk:${{matrix.splunk-version}}
         env:
           SPLUNK_START_ARGS: --accept-license
-          SPLUNK_PASSWORD: chamged!
+          SPLUNK_PASSWORD: changed!
         ports:
           - 8089
           - 8088

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,5 +70,5 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Acceptance Test
         uses: ./.github/actions/go-make-action
-          with:
-            target: 'test'
+        with:
+          target: 'test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,57 +4,14 @@ on:
   [push, pull_request]
 
 jobs:
-  unit-test:
-    strategy:
-      matrix:
-        java-version:
-          - 1.8
-          - 11
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java-version }}
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Unit Test
-        run: mvn -P Unittest -B verify --file pom.xml
-
-  acceptance-test:
-    needs: unit-test
+  dock-comp-test:
     strategy:
       matrix:
         splunk-version:
-          - 8.1
-          - 7.3
+          - latest
+          - 8.0
     runs-on: ubuntu-latest
     container: maven:3-jdk-8
-
-    services:
-      splunk:
-        image: splunk/splunk:${{matrix.splunk-version}}
-        env:
-          SPLUNK_START_ARGS: --accept-license
-          SPLUNK_PASSWORD: test_password
-        ports:
-          - 8089
-          - 8088
-          - 5555
-          - 15000
-          - 10667
-          - 10668/udp
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -68,8 +25,10 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Acceptance Test
-        run: mvn -P AcceptanceTest -B verify --file pom.xml
+      - name: Make Up
+        run: make up
+      - name: Make Test
+        run: make test
         env:
-          SPLUNK_PASSWORD: test_password
+          SPLUNK_PASSWORD: changed!
           SPLUNK_HOST: splunk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Set up docker
-        uses: isbang/compose-action@v1.0.0
-        #run: docker-compose up -d
+        run:  docker-compose -f "docker-compose.yml" up -d --build
 #      - name: Make Up
 #        run: make up
       - name: Unit Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Make up
-        run: make up
+#      - name: Make up
+#        run: make up
       - name: Make Test
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Set up docker
-        with:
-          file: ./docker-compose.yml
+        uses: isbang/compose-action@v1.0.0
         run: docker-compose up -d
 #      - name: Make Up
 #        run: make up

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,8 @@ jobs:
     strategy:
       matrix:
         splunk-version:
-          - 8.0
+          - "latest"
+          - "8.0"
     runs-on: ubuntu-latest
     container: maven:3-jdk-8
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 #        run: mvn -P Unittest -B verify --file pom.xml
 
   acceptance-test:
-    needs: unit-test
+#    needs: unit-test
     strategy:
       matrix:
         splunk-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,5 +68,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Acceptance Test
+      - name: Make up
+        run: make up
+      - name: Make Test
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,16 +5,13 @@ on:
 
 jobs:
 
-  tests:
-#    needs: unit-test
+  test-execution:
     strategy:
       matrix:
         splunk-version:
           - "latest"
           - "8.0"
     runs-on: ubuntu-latest
-    #container: maven:3-jdk-8
-
     services:
       splunk:
         image: splunk/splunk:${{matrix.splunk-version}}
@@ -29,7 +26,6 @@ jobs:
           - 15000:15000
           - 10667:10667
           - 10668:10668/udp
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -43,7 +39,5 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-#      - name: Make up
-#        run: make up
       - name: Make Test
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Set up docker
         uses: isbang/compose-action@v1.0.0
-        run: docker-compose up -d
+        #run: docker-compose up -d
 #      - name: Make Up
 #        run: make up
       - name: Unit Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,12 +48,13 @@ jobs:
           SPLUNK_START_ARGS: --accept-license
           SPLUNK_PASSWORD: changed!
         ports:
-          - 8089
-          - 8088
-          - 5555
-          - 15000
-          - 10667
-          - 10668/udp
+          - 8000:8000
+          - 5555:5555
+          - 8088:8088
+          - 8089:8089
+          - 15000:15000
+          - 10667:10667
+          - 10668:10668/udp
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     container: maven:3-jdk-8
     steps:
-      - name: Set up make
-      - run: sudo apt-get -y install make
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
@@ -27,6 +25,8 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Set up make
+        run: sudo apt-get -y install make
       - name: Make Up
         run: make up
       - name: Make Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,35 @@ on:
   [push, pull_request]
 
 jobs:
-  dock-comp-test:
+#  unit-test:
+#    strategy:
+#      matrix:
+#        java-version:
+#          - 1.8
+#          - 11
+#        os:
+#          - ubuntu-latest
+#          - windows-latest
+#          - macos-latest
+#    runs-on: ${{ matrix.os }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Set up JDK
+#        uses: actions/setup-java@v1
+#        with:
+#          java-version: ${{ matrix.java-version }}
+#      - name: Cache local Maven repository
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/.m2/repository
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
+#      - name: Unit Test
+#        run: mvn -P Unittest -B verify --file pom.xml
+
+  acceptance-test:
+    needs: unit-test
     strategy:
       matrix:
         splunk-version:
@@ -12,6 +40,21 @@ jobs:
           - 8.0
     runs-on: ubuntu-latest
     container: maven:3-jdk-8
+
+    services:
+      splunk:
+        image: splunk/splunk:${{matrix.splunk-version}}
+        env:
+          SPLUNK_START_ARGS: --accept-license
+          SPLUNK_PASSWORD: changed!
+        ports:
+          - 8089
+          - 8088
+          - 5555
+          - 15000
+          - 10667
+          - 10668/udp
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -25,14 +68,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Set up docker
-        run:  docker-compose -f "docker-compose.yml" up -d --build
-#      - name: Make Up
-#        run: make up
-      - name: Unit Test
-        run: mvn package -P Unittest
-#      - name: Acceptance Test
-#        run: mvn package -P AcceptanceTest
-        env:
-          SPLUNK_PASSWORD: changed!
-          SPLUNK_HOST: splunk
+      - name: Acceptance Test
+        uses: ./.github/actions/go-make-action
+          with:
+            target: 'test'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# text reset
+NO_COLOR=\033[0m
+# green
+OK_COLOR=\033[32;01m
+# red
+ERROR_COLOR=\033[31;01m
+# cyan
+WARN_COLOR=\033[36;01m
+# yellow
+ATTN_COLOR=\033[33;01m
+
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+
+VERSION := `git describe --tags --dirty 2>/dev/null`
+COMMITHASH := `git rev-parse --short HEAD 2>/dev/null`
+DATE := `date "+%FT%T%z"`
+
+.PHONY: all
+all: init test
+
+init:
+	@echo "$(ATTN_COLOR)==> init $(NO_COLOR)"
+
+.PHONY: test
+test:
+	@echo "$(ATTN_COLOR)==> test $(NO_COLOR)"
+	@echo "Running Unit test"
+	@mvn package -P Unittest
+	@echo "Running Acceptance test"
+	@mvn package -P AcceptanceTest
+	
+.PHONY: test_specific
+test_specific:
+	@echo "$(ATTN_COLOR)==> test_specific $(NO_COLOR)"
+	@sh ./scripts/test_specific.sh
+
+.PHONY: up
+up:
+	@echo "$(ATTN_COLOR)==> up $(NO_COLOR)"
+	@docker-compose up -d
+
+.PHONY: wait_up
+wait_up:
+	@echo "$(ATTN_COLOR)==> wait_up $(NO_COLOR)"
+	@for i in `seq 0 180`; do if docker exec -it splunk /sbin/checkstate.sh &> /dev/null; then break; fi; printf "\rWaiting for Splunk for %s seconds..." $$i; sleep 1; done
+
+.PHONY: down
+down:
+	@echo "$(ATTN_COLOR)==> down $(NO_COLOR)"
+	@docker-compose stop

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,9 @@ init:
 test:
 	@echo "$(ATTN_COLOR)==> test $(NO_COLOR)"
 	@echo "Running Unit test"
-	@mvn package -P Unittest
+	@mvn -P Unittest -B verify --file pom.xml
 	@echo "Running Acceptance test"
-	@mvn package -P AcceptanceTest
+	@mvn -P AcceptanceTest -B verify --file pom.xml
 	
 .PHONY: test_specific
 test_specific:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
     splunk:
-        image: splunk/splunk:${{matrix.splunk-version}}
+        image: splunk/splunk:latest
         container_name: splunk
         environment:
             - SPLUNK_START_ARGS=--accept-license

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
     splunk:
-        image: "splunk/splunk:latest"
+        image: splunk/splunk:${{matrix.splunk-version}}
         container_name: splunk
         environment:
             - SPLUNK_START_ARGS=--accept-license

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+    splunk:
+        image: "splunk/splunk:latest"
+        container_name: splunk
+        environment:
+            - SPLUNK_START_ARGS=--accept-license
+            - SPLUNK_PASSWORD=changed!
+        ports:
+            - 8000:8000
+            - 5555:5555
+            - 8088:8088
+            - 8089:8089
+            - 15000:15000
+            - 10667:10667
+            - 10668:10668/udp
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'https://localhost:8000']
+            interval: 5s
+            timeout: 5s
+            retries: 20

--- a/scripts/test_specific.sh
+++ b/scripts/test_specific.sh
@@ -1,0 +1,2 @@
+echo "To run a specific test:"
+echo "  mvn test -Dtest=[testclass]"

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -50,7 +50,7 @@ public class TestUtil {
             //set default value
             Map<String, String> environment = System.getenv();
             serviceArgs.setUsername(environment.getOrDefault("SPLUNK_USER", "admin"));
-            serviceArgs.setPassword(environment.getOrDefault("SPLUNK_PASSWORD", "changeme"));
+            serviceArgs.setPassword(environment.getOrDefault("SPLUNK_PASSWORD", "changed!"));
             serviceArgs.setHost(environment.getOrDefault("SPLUNK_HOST", "localhost"));
 
             serviceArgs.setPort(8089);
@@ -104,7 +104,7 @@ public class TestUtil {
                 }
             }
         }
-        // Use TLSv1 intead of SSLv3
+        // Use TLSv1 instead of SSLv3
         serviceArgs.setSSLSecurityProtocol(SSLSecurityProtocol.TLSv1_2);
     }
 


### PR DESCRIPTION
### Update:-
    

- Enabled following **make** commands: -
1. make up - Used to spin up Splunk Docker Instance.
2. make test - Used to run test cases against the Docker instance.
3. make test_specific - Used to echo the command, used to run specific test cases against the Docker instance.

- Added docker-compose.yml to spin up Splunk instance for local and CI.