### PR TITLE
Delayed time when using AsyncAppender

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorEventInfo.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorEventInfo.java
@@ -36,6 +36,7 @@ public class HttpEventCollectorEventInfo {
 
     /**
      * Create a new HttpEventCollectorEventInfo container
+     * @param timeMsSinceEpoch in milliseconds since "unix epoch"
      * @param severity of event
      * @param message is an event content
      * @param logger_name name of the logger
@@ -45,6 +46,7 @@ public class HttpEventCollectorEventInfo {
      * @param marker event marker
      */
     public HttpEventCollectorEventInfo(
+    		final long timeMsSinceEpoch,
             final String severity,
             final String message,
             final String logger_name,
@@ -53,7 +55,7 @@ public class HttpEventCollectorEventInfo {
             final String exception_message,
             final Serializable marker
     ) {
-        this.time = System.currentTimeMillis() / 1000.0;
+        this.time = timeMsSinceEpoch / 1000.0;
         this.severity = severity;
         this.message = message;
         this.logger_name = logger_name;

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -233,6 +233,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
     {
         // if an exception was thrown
         this.sender.send(
+        		event.getTimeMillis(),
                 event.getLevel().toString(),
                 getLayout().toSerializable(event).toString(),
                 includeLoggerName ? event.getLoggerName() : null,

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -145,6 +145,7 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
         MarkerConverter c = new MarkerConverter();
         if (this.started) {
             this.sender.send(
+            		event.getTimeStamp(),
                     event.getLevel().toString(),
                     _layout.doLayout((E) event),
                     _includeLoggerName ? event.getLoggerName() : null,

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
@@ -223,6 +223,7 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
     @Override
     public void publish(LogRecord record) {
         this.sender.send(
+        		record.getMillis(),
                 record.getLevel().toString(),
                 record.getMessage(),
                 includeLoggerName ? record.getLoggerName() : null,

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -167,6 +167,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
      * @param message event text
      */
     public synchronized void send(
+    		final long timeMsSinceEpoch,
             final String severity,
             final String message,
             final String logger_name,
@@ -177,7 +178,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     ) {
         // create event info container and add it to the batch
         HttpEventCollectorEventInfo eventInfo =
-                new HttpEventCollectorEventInfo(severity, message, logger_name, thread_name, properties, exception_message, marker);
+                new HttpEventCollectorEventInfo(timeMsSinceEpoch, severity, message, logger_name, thread_name, properties, exception_message, marker);
         eventsBatch.add(eventInfo);
         eventsBatchSize += severity.length() + message.length();
         if (eventsBatch.size() >= maxEventsBatchCount || eventsBatchSize > maxEventsBatchSize) {
@@ -190,7 +191,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
      * @param message event text
      */
     public synchronized void send(final String message) {
-        send("", message, "", "", null, null, "");
+        send(System.currentTimeMillis(), "", message, "", "", null, null, "");
     }
 
     /**


### PR DESCRIPTION
When logging under an AsyncAppender timestamps were being reported at the time that the log event was sent, which could be many seconds after when the log event occurred. Now timestamps are extracted from the original log event instead of being calculated when they're sent over the wire.

#185 