### PR TITLE
Change default behavior for the Splunk event header metadata and body back to that of version 1.7.3.

### DIFF
--- a/src/main/java/com/splunk/logging/serialization/EventInfoTypeAdapter.java
+++ b/src/main/java/com/splunk/logging/serialization/EventInfoTypeAdapter.java
@@ -23,9 +23,6 @@ public class EventInfoTypeAdapter implements JsonSerializer<HttpEventCollectorEv
         // but Spring Boot does some Gradle magic that downgrades (as of 11/2019) to 1.8.5. This
         // should move to static methods once 1.8.6 has widespread adoption.
         JsonParser parser = new JsonParser();
-        if (src.getTime() > 0) {
-            event.put("time", String.format(Locale.US, "%.3f", src.getTime()));
-        }
         if (src.getSeverity() != null) {
             event.put("severity", src.getSeverity());
         }

--- a/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
+++ b/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
@@ -53,6 +53,7 @@ public class HecJsonSerializer {
             event = eventHeaderSerializer.serializeEventHeader(info, new HashMap<>(template));
         } else {
             event = new HashMap<>(template);
+            event.put("time", String.format(Locale.US, "%.3f", info.getTime()));
         }
         if (this.eventBodySerializer != null) {
             event.put("event", eventBodySerializer.serializeEventBody(info, info.getMessage()));


### PR DESCRIPTION
Change default behavior for the Splunk event header metadata and body back to that of version 1.7.3. This relates to issue #197.