### PR TITLE
Fix for issue #183 - okHttpClient timeout settings

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -28,8 +28,8 @@ import javax.net.ssl.*;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.cert.CertificateException;
-import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 
@@ -277,6 +277,11 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
 
         OkHttpClient.Builder builder = httpSharedClient.newBuilder();
 
+        builder.connectTimeout(timeoutSettings.connectTimeout, TimeUnit.MILLISECONDS)
+                .callTimeout(timeoutSettings.callTimeout, TimeUnit.MILLISECONDS)
+                .readTimeout(timeoutSettings.readTimeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(timeoutSettings.writeTimeout, TimeUnit.MILLISECONDS);
+
         // limit max  number of async requests in sequential mode
         if (sendMode == SendMode.Sequential) {
             Dispatcher dispatcher = new Dispatcher();
@@ -318,11 +323,6 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
                 }
             });
         }
-
-        builder.connectTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_CONNECT_TIMEOUT));
-        builder.readTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_READ_TIMEOUT));
-        builder.writeTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_WRITE_TIMEOUT));
-        builder.callTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_CALL_TIMEOUT));
 
         httpClient = builder.build();
     }

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -318,6 +318,11 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             });
         }
 
+        builder.connectTimeout(TimeoutSettings.DEFAULT_CONNECT_TIMEOUT);
+        builder.readTimeout(TimeoutSettings.DEFAULT_READ_TIMEOUT);
+        builder.writeTimeout(TimeoutSettings.DEFAULT_WRITE_TIMEOUT);
+        builder.callTimeout(TimeoutSettings.DEFAULT_CALL_TIMEOUT);
+
         httpClient = builder.build();
     }
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -28,6 +28,7 @@ import javax.net.ssl.*;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.cert.CertificateException;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -318,10 +319,10 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             });
         }
 
-        builder.connectTimeout(TimeoutSettings.DEFAULT_CONNECT_TIMEOUT);
-        builder.readTimeout(TimeoutSettings.DEFAULT_READ_TIMEOUT);
-        builder.writeTimeout(TimeoutSettings.DEFAULT_WRITE_TIMEOUT);
-        builder.callTimeout(TimeoutSettings.DEFAULT_CALL_TIMEOUT);
+        builder.connectTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_CONNECT_TIMEOUT));
+        builder.readTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_READ_TIMEOUT));
+        builder.writeTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_WRITE_TIMEOUT));
+        builder.callTimeout(Duration.ofMillis(TimeoutSettings.DEFAULT_CALL_TIMEOUT));
 
         httpClient = builder.build();
     }

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -277,6 +277,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
 
         OkHttpClient.Builder builder = httpSharedClient.newBuilder();
 
+        // set timeouts
         builder.connectTimeout(timeoutSettings.connectTimeout, TimeUnit.MILLISECONDS)
                 .callTimeout(timeoutSettings.callTimeout, TimeUnit.MILLISECONDS)
                 .readTimeout(timeoutSettings.readTimeout, TimeUnit.MILLISECONDS)
@@ -395,10 +396,10 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     }
 
     public static class TimeoutSettings {
-        public static final long DEFAULT_CONNECT_TIMEOUT = 30000;
-        public static final long DEFAULT_WRITE_TIMEOUT = 0; // 0 means no timeout
+        public static final long DEFAULT_CONNECT_TIMEOUT = 3000;
+        public static final long DEFAULT_WRITE_TIMEOUT = 10000; // 0 means no timeout
         public static final long DEFAULT_CALL_TIMEOUT = 0;
-        public static final long DEFAULT_READ_TIMEOUT = 0;
+        public static final long DEFAULT_READ_TIMEOUT = 10000;
 
         public long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
         public long callTimeout = DEFAULT_CALL_TIMEOUT;


### PR DESCRIPTION
This is the proposed fix for #183 where the timeout settings do not appear to get used for the http client configuration.