### PR TITLE
Release- 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Splunk Logging for Java Changelog
 
+## Version 1.11.0
+
+### Minor Changes
+* Added a parameter to set await termination timeout. [PR](https://github.com/splunk/splunk-library-javalogging/pull/179)
+
 ## Version 1.10.0
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Logging for Java
 
-#### Version 1.10.0
+#### Version 1.11.0
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.splunk.logging</groupId>
     <artifactId>splunk-library-javalogging</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0</version>
     <packaging>jar</packaging>
 
     <name>Splunk Logging for Java</name>


### PR DESCRIPTION
Added a parameter to set await termination timeout. [PR](https://github.com/splunk/splunk-library-javalogging/pull/179)