### PR TITLE
Expose flush() method on Logback and Log4j appenders to flush underlying HttpEventCollectorSender and OkHttpClient

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -245,6 +245,10 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
         );
     }
 
+    public void flush() {
+        sender.flush();
+    }
+
     @Override
     public boolean stop(long timeout, TimeUnit timeUnit) {
         this.sender.close();

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -406,7 +406,5 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
             return defaultValue;
         }
     }
-
-
 }
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -119,6 +119,12 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
         super.start();
     }
 
+    public void flush() {
+        if (started) {
+            sender.flush();
+        }
+    }
+
     @Override
     public void stop() {
         if (!started)
@@ -400,5 +406,7 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
             return defaultValue;
         }
     }
+
+
 }
 

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -196,9 +196,18 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     }
 
     /**
-     * Flush all pending events
+     * Flush all pending events to the underlying HTTP client
+     * and then flush the HTTP client itself (keeping the client
+     * open to accept further events)
      */
     public synchronized void flush() {
+        flush(false);
+    }
+
+    /**
+     * Flush all pending events to the underlying HTTP client
+     */
+    private synchronized void flushEvents() {
         if (eventsBatch.size() > 0) {
             postEventsAsync(eventsBatch);
         }
@@ -210,9 +219,11 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     }
 
     public synchronized void flush(boolean close) {
-        flush();
+        flushEvents();
         if (close) {
             stopHttpClient();
+        } else {
+            flushHttpClient();
         }
     }
 
@@ -222,8 +233,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     void close() {
         if (timer != null)
             timer.cancel();
-        flush();
-        stopHttpClient();
+        flush(true);
         super.cancel();
     }
 
@@ -232,7 +242,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
      */
     @Override // TimerTask
     public void run() {
-        flush();
+        flushEvents();
     }
 
     /**
@@ -261,6 +271,28 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
         }
     }
 
+    private void flushHttpClient() {
+        flushHttpClient(timeoutSettings.terminationTimeout);
+    }
+
+    private void flushHttpClient(long timeout) {
+        if (httpClient != null && timeout > 0) {
+            Dispatcher dispatcher = httpClient.dispatcher();
+
+            long start = System.currentTimeMillis();
+
+            while (dispatcher.queuedCallsCount() > 0 &&
+                    dispatcher.runningCallsCount() > 0 &&
+                    start + timeout > System.currentTimeMillis()) {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(30);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+    }
 
     private void stopHttpClient() {
         if (httpClient != null) {


### PR DESCRIPTION
Build upon the previous partial solution to https://github.com/splunk/splunk-library-javalogging/issues/152

Instead of stopping the appender at then end of a lambda function, just call `flush()` on the appender.

This way the appender can be re-used next time the lambda function is invoked.

The underlying httpClient is flushed (up to the configured timeout).