### PR TITLE
Debug failing HttpEventCollector_Log4j2Test

### DIFF
--- a/src/test/java/HttpEventCollectorUnitTest.java
+++ b/src/test/java/HttpEventCollectorUnitTest.java
@@ -23,7 +23,9 @@ import java.net.InetSocketAddress;
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import sun.rmi.runtime.Log;
 
 import java.io.ByteArrayInputStream;
@@ -34,6 +36,10 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 public class HttpEventCollectorUnitTest {
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
+
     @Test
     public void log4j_simple() throws Exception {
         HashMap<String, String> userInputs = new HashMap<String, String>();

--- a/src/test/java/HttpEventCollector_JavaLoggingTest.java
+++ b/src/test/java/HttpEventCollector_JavaLoggingTest.java
@@ -23,7 +23,9 @@ import com.splunk.logging.HttpEventCollectorEventInfo;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import java.util.logging.Logger;
 
@@ -32,6 +34,9 @@ public final class HttpEventCollector_JavaLoggingTest {
     private String httpEventCollectorName = "JavaLoggingTest";
     List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<List<HttpEventCollectorEventInfo>>();
     List<HttpEventCollectorErrorHandler.ServerErrorException> logEx = new ArrayList<HttpEventCollectorErrorHandler.ServerErrorException>();
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
 
     /**
      * sending a message via httplogging using java.logging to splunk
@@ -430,7 +435,6 @@ public final class HttpEventCollector_JavaLoggingTest {
         TestUtil.verifyEventsSentInOrder(prefix, totalEventsCount, indexName);
 
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
-        System.out.println("====================== Test pass=========================");
     }
 
     /**

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -29,8 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.apache.logging.log4j.Logger;
 import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
 public final class HttpEventCollector_Log4j2Test {
     private String httpEventCollectorName = "Log4j2Test";
@@ -38,20 +36,7 @@ public final class HttpEventCollector_Log4j2Test {
     List<HttpEventCollectorErrorHandler.ServerErrorException> logEx = new ArrayList<>();
 
     @Rule
-    public TestRule watcher = new TestWatcher() {
-        protected void starting(Description description) {
-            System.out.println("Starting test: " + description.getMethodName());
-        }
-
-        protected void succeeded(Description description) {
-            System.out.println("====================== Test pass=========================");
-        }
-
-        protected void finished(Description description) {
-            // GitHub pipeline is not including output from last test failure
-            System.out.flush();
-        }
-    };
+    public TestRule watcher = new SplunkTestWatcher();
 
     /**
      * sending a message via httplogging using log4j2 to splunk

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -277,7 +277,7 @@ public final class HttpEventCollector_Log4j2Test {
         System.out.println("======print logEx");
         System.out.println(logEx.toString());
         System.out.println("======finish print logEx");
-        Assert.assertEquals("Invalid token", logEx.get(1).getErrorText()); // Failing on main branch
+        Assert.assertEquals("Invalid token", logEx.get(1).getErrorText());
         Assert.assertEquals(4, logEx.get(1).getErrorCode());
 
 

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -274,7 +274,7 @@ public final class HttpEventCollector_Log4j2Test {
         System.out.println("======print logEx");
         System.out.println(logEx.toString());
         System.out.println("======finish print logEx");
-        Assert.assertEquals("Invalid token", logEx.get(1).getErrorText());
+        Assert.assertEquals("Invalid token", logEx.get(1).getErrorText()); // Failing on main branch
         Assert.assertEquals(4, logEx.get(1).getErrorCode());
 
 

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -25,13 +25,33 @@ import com.splunk.logging.HttpEventCollectorEventInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.apache.logging.log4j.Logger;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 public final class HttpEventCollector_Log4j2Test {
     private String httpEventCollectorName = "Log4j2Test";
     List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<List<HttpEventCollectorEventInfo>>();
     List<HttpEventCollectorErrorHandler.ServerErrorException> logEx = new ArrayList<>();
+
+    @Rule
+    public TestRule watcher = new TestWatcher() {
+        protected void starting(Description description) {
+            System.out.println("Starting test: " + description.getMethodName());
+        }
+
+        protected void succeeded(Description description) {
+            System.out.println("====================== Test pass=========================");
+        }
+
+        protected void finished(Description description) {
+            // GitHub pipeline is not including output from last test failure
+            System.out.flush();
+        }
+    };
 
     /**
      * sending a message via httplogging using log4j2 to splunk
@@ -62,7 +82,6 @@ public final class HttpEventCollector_Log4j2Test {
         TestUtil.verifyEventsSentToSplunk(msgs);
 
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
-        System.out.println("====================== Test pass=========================");
     }
 
 
@@ -100,7 +119,6 @@ public final class HttpEventCollector_Log4j2Test {
         TestUtil.verifyEventsSentToSplunk(msgs);
 
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
-        System.out.println("====================== Test pass=========================");
     }
 
     /**
@@ -368,7 +386,6 @@ public final class HttpEventCollector_Log4j2Test {
         TestUtil.verifyEventsSentInOrder(prefix,totalEventsCount,indexName);
 
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
-        System.out.println("====================== Test pass=========================");
     }
     
     /**

--- a/src/test/java/HttpEventCollector_LogbackTest.java
+++ b/src/test/java/HttpEventCollector_LogbackTest.java
@@ -23,7 +23,9 @@ import com.splunk.logging.HttpEventCollectorEventInfo;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +34,9 @@ public final class HttpEventCollector_LogbackTest {
     private String httpEventCollectorName = "LogbackTest";
     List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<List<HttpEventCollectorEventInfo>>();
     List<HttpEventCollectorErrorHandler.ServerErrorException> logEx = new ArrayList<HttpEventCollectorErrorHandler.ServerErrorException>();
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
 
     /**
      * sending a message via httplogging using logback to splunk
@@ -361,7 +366,6 @@ public final class HttpEventCollector_LogbackTest {
         TestUtil.verifyEventsSentInOrder(prefix, totalEventsCount, indexName);
 
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
-        System.out.println("====================== Test pass=========================");
     }
     
     /**

--- a/src/test/java/HttpEventCollector_Test.java
+++ b/src/test/java/HttpEventCollector_Test.java
@@ -20,6 +20,7 @@ import ch.qos.logback.core.joran.spi.JoranException;
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.*;
@@ -30,6 +31,7 @@ import java.util.*;
 import java.lang.reflect.*;
 
 import com.splunk.*;
+import org.junit.rules.TestRule;
 import org.slf4j.*;
 
 public class HttpEventCollector_Test {
@@ -89,6 +91,9 @@ public class HttpEventCollector_Test {
         String token=TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
         return token;
     }
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
 
     @Test
     public void LogToSplunkViaDifferentLoggers() throws Exception {

--- a/src/test/java/HttpLoggerStressTest.java
+++ b/src/test/java/HttpLoggerStressTest.java
@@ -2,6 +2,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.*;
@@ -12,6 +13,7 @@ import java.util.*;
 import java.lang.reflect.*;
 
 import com.splunk.*;
+import org.junit.rules.TestRule;
 
 public class HttpLoggerStressTest {
     private static class DataSender implements Runnable {
@@ -104,6 +106,9 @@ public class HttpLoggerStressTest {
         userInputs.put("user_batch_size_count", "1");
         TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
     }
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
 
     @Test
     public void canSendEventUsingJavaLogging() throws Exception {

--- a/src/test/java/JULFunctionalTest.java
+++ b/src/test/java/JULFunctionalTest.java
@@ -14,7 +14,9 @@
  * under the License.
  */
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -25,6 +27,9 @@ import java.net.Socket;
 import java.util.logging.Logger;
 
 public class JULFunctionalTest {
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
 
     /**
      * Try writing a message via TCP to java.util.logging to validate the example configuration.

--- a/src/test/java/Log4jFunctionalTest.java
+++ b/src/test/java/Log4jFunctionalTest.java
@@ -16,9 +16,14 @@
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 public class Log4jFunctionalTest {
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
 
     /**
      * Try writing a message via TCP to log4j 2 to validate the example configuration.

--- a/src/test/java/LogbackFunctionalTest.java
+++ b/src/test/java/LogbackFunctionalTest.java
@@ -14,11 +14,16 @@
  * under the License.
  */
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LogbackFunctionalTest {
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
 
     /**
      * Try writing a message via TCP to logback to validate the example configuration.

--- a/src/test/java/SplunkCimLogEventUnitTest.java
+++ b/src/test/java/SplunkCimLogEventUnitTest.java
@@ -16,7 +16,9 @@
 
 import com.splunk.logging.SplunkCimLogEvent;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -25,6 +27,10 @@ import java.util.regex.Pattern;
  * Check that SplunkCimLogEvent produces what we expect it to.
  */
 public class SplunkCimLogEventUnitTest {
+
+    @Rule
+    public TestRule watcher = new SplunkTestWatcher();
+
     @Test
     public void addFieldWithCharValue() {
         SplunkCimLogEvent event = new SplunkCimLogEvent("name", "event-id");

--- a/src/test/java/SplunkTestWatcher.java
+++ b/src/test/java/SplunkTestWatcher.java
@@ -1,0 +1,21 @@
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class SplunkTestWatcher extends TestWatcher {
+
+    @Override
+    protected void starting(Description description) {
+        System.out.println("Starting test: " + description.getMethodName());
+    }
+
+    @Override
+    protected void succeeded(Description description) {
+        System.out.println("====================== Test pass=========================");
+    }
+
+    @Override
+    protected void finished(Description description) {
+        // GitHub pipeline is not including output from last test failure
+        System.out.flush();
+    }
+}


### PR DESCRIPTION
Confirm that the HttpEventCollector_Log4j2Test is failing on the main branch.

The test is failing in both https://github.com/splunk/splunk-library-javalogging/pull/207 and https://github.com/splunk/splunk-library-javalogging/pull/208

I suspect the test failure is unrelated to any changes from those pull requests, and will fail also on the main branch.

Unfortunately, the `println` statements from the failing test are missing from the GitHub CI output.

This pull request aims to further debug this failing test by:
Adding a TestWatcher rule to log test name on start, 
Consolidate the "Test Pass" messages,
And, flush stdout when each test completes.

You can see here (https://github.com/splunk/splunk-library-javalogging/runs/4001980946?check_suite_focus=true#step:6:1111) that the output from the failing test is not included.

I would expect to see the output from the `System.out.println` statements here: https://github.com/stevejagodzinski/splunk-library-javalogging/blob/feature/use-jdk8-source-features/src/test/java/HttpEventCollector_Log4j2Test.java#L269