### PR TITLE
Set default time

### DIFF
--- a/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
+++ b/src/main/java/com/splunk/logging/serialization/HecJsonSerializer.java
@@ -63,6 +63,10 @@ public class HecJsonSerializer {
         } else {
             event.put("event", info);
         }
+        if (!event.containsKey("time") && info.getTime() > 0) {
+            // We haven't figured any other time - so use the time from the event.
+            event.put("time", String.format(Locale.US, "%.3f", info.getTime()));
+        }
         return gson.toJson(event);
     }
 

--- a/src/test/java/HecJsonSerializerTest.java
+++ b/src/test/java/HecJsonSerializerTest.java
@@ -69,12 +69,7 @@ public class HecJsonSerializerTest {
     @SuppressWarnings("unchecked")
     public void itShouldPopulateTheTimeIfBodyOverrideDoesntSetTime() {
         HecJsonSerializer serializer = new HecJsonSerializer(Collections.emptyMap());
-        serializer.setEventBodySerializer(new EventBodySerializer() {
-            @Override
-            public String serializeEventBody(final HttpEventCollectorEventInfo eventInfo, final Object formattedMessage) {
-                return "XXX";
-            }
-        });
+        serializer.setEventBodySerializer((eventInfo, formattedMessage) -> "XXX");
         String result = serializer.serialize(event);
         Map<String, Object> map = (Map<String, Object>) gson.fromJson(result, Map.class);
         Assert.assertEquals("1636473405.870", map.get("time"));

--- a/src/test/java/HecJsonSerializerTest.java
+++ b/src/test/java/HecJsonSerializerTest.java
@@ -1,0 +1,82 @@
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.splunk.logging.EventBodySerializer;
+import com.splunk.logging.HttpEventCollectorEventInfo;
+import com.splunk.logging.serialization.HecJsonSerializer;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("unchecked")
+public class HecJsonSerializerTest {
+    private final Gson gson = new GsonBuilder()
+        .disableHtmlEscaping()
+        .create();
+
+    private final HttpEventCollectorEventInfo event = new HttpEventCollectorEventInfo(1636473405870L, "INFO", "Test Message", "MyLogger", "Thread", Collections.emptyMap(), null, null);
+
+    @Test
+    public void itShouldPopulateTheTime() {
+        HecJsonSerializer serializer = new HecJsonSerializer(Collections.emptyMap());
+        String result = serializer.serialize(event);
+        Map<String, Object> map = (Map<String, Object>) gson.fromJson(result, Map.class);
+        Assert.assertEquals("1636473405.870", map.get("time"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void itShouldNotPopulateTheTimeIfAlreadyPopulated() {
+        HecJsonSerializer serializer = new HecJsonSerializer(Collections.singletonMap("time", "1234.567"));
+        String result = serializer.serialize(event);
+        Map<String, Object> map = (Map<String, Object>) gson.fromJson(result, Map.class);
+        Assert.assertEquals("1234.567", map.get("time"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void itShouldNotPopulateTheTimeIfHeaderPopulates() {
+        HecJsonSerializer serializer = new HecJsonSerializer(Collections.emptyMap());
+        serializer.setEventHeaderSerializer((eventInfo, metadata) -> new HashMap<>(Collections.singletonMap("time", "12345.678")));
+        String result = serializer.serialize(event);
+        Map<String, Object> map = (Map<String, Object>) gson.fromJson(result, Map.class);
+        Assert.assertEquals("12345.678", map.get("time"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void itShouldNotPopulateTheTimeIfBodyPopulates() {
+        HecJsonSerializer serializer = new HecJsonSerializer(Collections.emptyMap());
+        serializer.setEventBodySerializer(new EventBodySerializer() {
+            @Override
+            public String serializeEventBody(final HttpEventCollectorEventInfo eventInfo, final Object formattedMessage) {
+                return "XXX";
+            }
+
+            @Override
+            public double getEventTime(final HttpEventCollectorEventInfo eventInfo) {
+                return 1.0d;
+            }
+        });
+        String result = serializer.serialize(event);
+        Map<String, Object> map = (Map<String, Object>) gson.fromJson(result, Map.class);
+        Assert.assertEquals("1.000", map.get("time"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void itShouldPopulateTheTimeIfBodyOverrideDoesntSetTime() {
+        HecJsonSerializer serializer = new HecJsonSerializer(Collections.emptyMap());
+        serializer.setEventBodySerializer(new EventBodySerializer() {
+            @Override
+            public String serializeEventBody(final HttpEventCollectorEventInfo eventInfo, final Object formattedMessage) {
+                return "XXX";
+            }
+        });
+        String result = serializer.serialize(event);
+        Map<String, Object> map = (Map<String, Object>) gson.fromJson(result, Map.class);
+        Assert.assertEquals("1636473405.870", map.get("time"));
+    }
+}


### PR DESCRIPTION
If the header or body serializers do not set the time in the header, then use the time data from the event.
This stops the events from just using the batch arrival time, which is effectively a useless time.
