### PR TITLE
added StandardErrorCallback class plus errorCallback field for config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Splunk Logging for Java Changelog
 
-## Version 1.12.0
-
-* Added StandardErrorCallback. Register ErrorCallback implementations via logback or log4j xml config. (@stokpop)
-
 ## Version 1.11.4
 
 ### Critical Security Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Splunk Logging for Java Changelog
 
+## Version 1.12.0
+
+* Added StandardErrorCallback. Register ErrorCallback implementations via logback or log4j xml config. (@stokpop)
+
 ## Version 1.11.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Logging for Java
 
-#### Version 1.11.0
+#### Version 1.12.0
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 
@@ -11,6 +11,8 @@ Splunk logging for Java provides:
 * Handler classes that export the logging events.
 
 * An optional error handler to catch failures for HTTP Event Collector events.
+  * Use `com.splunk.logging.util.StandardErrorCallback` to write errors to standard out.
+  * Use the `errorCallback` field in logging configs to register a ErrorCallback class.
 
 * Example configuration files for all three frameworks that show how to configure the frameworks to write to HTTP Event Collector or TCP ports.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Logging for Java
 
-#### Version 1.12.0
+#### Version 1.11.4
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 
@@ -11,8 +11,6 @@ Splunk logging for Java provides:
 * Handler classes that export the logging events.
 
 * An optional error handler to catch failures for HTTP Event Collector events.
-  * Use `com.splunk.logging.util.StandardErrorCallback` to write errors to standard out.
-  * Use the `errorCallback` field in logging configs to register a ErrorCallback class.
 
 * Example configuration files for all three frameworks that show how to configure the frameworks to write to HTTP Event Collector or TCP ports.
 
@@ -28,7 +26,7 @@ If you haven't already installed Splunk, download it
 [here](http://www.splunk.com/download). For more about installing and running
 Splunk and system requirements, see [Installing & Running Splunk](http://dev.splunk.com/view/SP-CAAADRV). Splunk logging for Java is tested with Splunk Enterprise 8.0 and 8.2.0.
 
-#### Java 
+#### Java
 
 You'll need Java version 8 or higher, from [OpenJDK](https://openjdk.java.net) or [Oracle](https://www.oracle.com/technetwork/java).
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.splunk.logging</groupId>
     <artifactId>splunk-library-javalogging</artifactId>
-    <version>1.11.0</version>
+    <version>1.12.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Splunk Logging for Java</name>

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLog4jAppender.java
@@ -148,6 +148,7 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
             @PluginAttribute("disableCertificateValidation") final String disableCertificateValidation,
             @PluginAttribute("eventBodySerializer") final String eventBodySerializer,
             @PluginAttribute("eventHeaderSerializer") final String eventHeaderSerializer,
+            @PluginAttribute("errorCallback") final String errorCallback,
             @PluginAttribute(value = "includeLoggerName", defaultBoolean = true) final boolean includeLoggerName,
             @PluginAttribute(value = "includeThreadName", defaultBoolean = true) final boolean includeThreadName,
             @PluginAttribute(value = "includeMDC", defaultBoolean = true) final boolean includeMDC,
@@ -201,6 +202,10 @@ public final class HttpEventCollectorLog4jAppender extends AbstractAppender
                     .withAlwaysWriteExceptions(true)
                     .withNoConsoleNoAnsi(false)
                     .build();
+        }
+
+        if (errorCallback != null) {
+            HttpEventCollectorErrorHandler.registerClassName(errorCallback);
         }
 
         final boolean ignoreExceptionsBool = Boolean.getBoolean(ignoreExceptions);

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLogbackAppender.java
@@ -47,6 +47,7 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
     private String _middleware;
     private String _eventBodySerializer;
     private String _eventHeaderSerializer;
+    private String _errorCallback;
     private long _batchInterval = 0;
     private long _batchCount = 0;
     private long _batchSize = 0;
@@ -105,6 +106,10 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
             try {
                 this.sender.setEventHeaderSerializer((EventHeaderSerializer) Class.forName(_eventHeaderSerializer).newInstance());
             } catch (final Exception ignored) {}
+        }
+
+        if (_errorCallback != null && !_errorCallback.isEmpty()) {
+            HttpEventCollectorErrorHandler.registerClassName(_errorCallback);
         }
 
         // plug resend middleware
@@ -305,6 +310,10 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
         return _eventHeaderSerializer;
     }
 
+    public String getErrorHandler(String errorHandlerClass) {
+        return this._errorCallback;
+    }
+
     public void setDisableCertificateValidation(String disableCertificateValidation) {
         this._disableCertificateValidation = disableCertificateValidation;
     }
@@ -349,6 +358,14 @@ public class HttpEventCollectorLogbackAppender<E> extends AppenderBase<E> {
 
     public void setEventHeaderSerializer(String eventHeaderSerializer) {
         this._eventHeaderSerializer = eventHeaderSerializer;
+    }
+
+    public void setErrorCallback(String errorHandlerClass) {
+        this._errorCallback = errorHandlerClass;
+    }
+
+    public String getErrorCallback() {
+        return this._errorCallback;
     }
 
     public void setConnectTimeout(long milliseconds) {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorLoggingHandler.java
@@ -157,6 +157,7 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
         String eventHeaderSerializer = getConfigurationProperty("eventHeaderSerializer", "");
         String middleware = getConfigurationProperty(MiddlewareTag, null);
         String eventBodySerializer = getConfigurationProperty("eventBodySerializer", null);
+        String errorCallbackClass = getConfigurationProperty("errorCallback", null);
 
         includeLoggerName = getConfigurationBooleanProperty(IncludeLoggerNameConfTag, true);
         includeThreadName = getConfigurationBooleanProperty(IncludeThreadNameConfTag, true);
@@ -207,6 +208,16 @@ public final class HttpEventCollectorLoggingHandler extends Handler {
                 System.out.println(ex);
             }
         }
+
+        if (errorCallbackClass != null && !errorCallbackClass.isEmpty()) {
+            try {
+                HttpEventCollectorErrorHandler.registerClassName(errorCallbackClass);
+            } catch (final Exception ex) {
+                //output error msg but not fail, it will default to use the default EventHeaderSerializer
+                System.out.println(ex);
+            }
+        }
+
 
         // plug retries middleware
         if (retriesOnError > 0) {

--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -363,10 +363,8 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
             }
 
             @Override
-            public void failed(Exception ex) {
-                HttpEventCollectorErrorHandler.error(
-                        events,
-                        new HttpEventCollectorErrorHandler.ServerErrorException(ex.getMessage()));
+            public void failed(Exception exception) {
+                HttpEventCollectorErrorHandler.error(events, exception);
             }
         });
     }

--- a/src/main/java/com/splunk/logging/util/StandardErrorCallback.java
+++ b/src/main/java/com/splunk/logging/util/StandardErrorCallback.java
@@ -1,0 +1,117 @@
+package com.splunk.logging.util;
+
+import com.splunk.logging.HttpEventCollectorErrorHandler;
+import com.splunk.logging.HttpEventCollectorEventInfo;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Print errors to standard out because sending events to Splunk has exceptions and
+ * logging frameworks might be disabled or broken.
+ *
+ * Enable printStackTraces via property: <code>-Dcom.splunk.logging.util.StandardErrorCallback.enablePrintStackTrace=true</code>
+ */
+public class StandardErrorCallback implements HttpEventCollectorErrorHandler.ErrorCallback {
+
+    public static final Locale DEFAULT_LOCALE = Locale.US;
+
+    private static final AtomicInteger eventCount = new AtomicInteger(0);
+    private static final AtomicInteger errorCount = new AtomicInteger(0);
+
+    private static final DateTimeFormatter HUMAN_READABLE_WITH_MILLIS =
+        new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd HH:mm:ss.SSS").toFormatter(DEFAULT_LOCALE);
+
+    private final boolean enablePrintStackTrace;
+
+    public StandardErrorCallback() {
+        this(checkEnablePrintStackTrace());
+    }
+
+    private static boolean checkEnablePrintStackTrace() {
+        return "true".equalsIgnoreCase(System.getProperty("com.splunk.logging.util.StandardErrorCallback.enablePrintStackTrace", "false"));
+    }
+
+    public StandardErrorCallback(boolean enablePrintStackTrace) {
+        this.enablePrintStackTrace = enablePrintStackTrace;
+    }
+
+    @Override
+    public void error(List<HttpEventCollectorEventInfo> data, Exception ex) {
+        int totalErrorCount = errorCount.incrementAndGet();
+        int totalEventCount = eventCount.addAndGet(data == null ? 0 : data.size());
+
+        String threadName = Thread.currentThread().getName();
+
+        String fullMessage = createErrorMessage(data, ex, totalErrorCount, totalEventCount, threadName);
+
+        printError(fullMessage);
+
+        printStackTrace(ex);
+    }
+
+    private String createErrorMessage(List<HttpEventCollectorEventInfo> data, Exception ex, int totalErrorCount, int totalEventCount, String threadName) {
+
+        String timestamp = HUMAN_READABLE_WITH_MILLIS.format(LocalDateTime.now());
+        String exceptionMessage = ex == null ? "unknown (exception null)" : ex.getClass().getSimpleName() + ": " + ex.getMessage();
+
+        final String batchOrSingleText = createBatchOrSingleText(data);
+
+        String fullMessage = timestamp
+            + " [" + threadName + "] HttpEventCollectorError exception for "
+            + batchOrSingleText + ". Total errors/events: " + totalErrorCount + "/" + totalEventCount + ". Message: " + exceptionMessage;
+
+        return fullMessage;
+    }
+
+    private String createBatchOrSingleText(List<HttpEventCollectorEventInfo> data) {
+        final String batchOrSingleText;
+        if (data == null) {
+            batchOrSingleText = "unknown events (data is null)";
+        }
+        else {
+            int size = data.size();
+            if (size == 1) {
+                batchOrSingleText = "log event";
+            } else {
+                batchOrSingleText = "batch of " + size + " log events";
+            }
+        }
+        return batchOrSingleText;
+    }
+
+    private void printStackTrace(Exception ex) {
+        if (enablePrintStackTrace) {
+            if (ex != null) {
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    private void printError(String fullMessage) {
+        System.err.println(fullMessage);
+    }
+
+    public int getEventCount() {
+        return eventCount.get();
+    }
+
+    public int getErrorCount() {
+        return errorCount.get();
+    }
+
+    public void resetCounters() {
+        // should maybe be atomic thread safe action, complicated, good enough?
+        errorCount.set(0);
+        eventCount.set(0);
+    }
+
+    public boolean isPrintStackTraceEnabled() {
+        return enablePrintStackTrace;
+    }
+
+}

--- a/src/test/java/HttpEventCollector_JavaLoggingTest.java
+++ b/src/test/java/HttpEventCollector_JavaLoggingTest.java
@@ -31,7 +31,7 @@ public final class HttpEventCollector_JavaLoggingTest {
 
     private String httpEventCollectorName = "JavaLoggingTest";
     List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<List<HttpEventCollectorEventInfo>>();
-    List<HttpEventCollectorErrorHandler.ServerErrorException> logEx = new ArrayList<HttpEventCollectorErrorHandler.ServerErrorException>();
+    List<Exception> logEx = new ArrayList<>();
 
     /**
      * sending a message via httplogging using java.logging to splunk
@@ -236,12 +236,10 @@ public final class HttpEventCollector_JavaLoggingTest {
         errors.clear();
         logEx.clear();
         //define error callback
-        HttpEventCollectorErrorHandler.onError(new HttpEventCollectorErrorHandler.ErrorCallback() {
-            public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {
-                synchronized (errors) {
-                    errors.add(data);
-                    logEx.add((HttpEventCollectorErrorHandler.ServerErrorException) ex);
-                }
+        HttpEventCollectorErrorHandler.onError((data, ex) -> {
+            synchronized (errors) {
+                errors.add(data);
+                logEx.add(ex);
             }
         });
 
@@ -282,8 +280,10 @@ public final class HttpEventCollector_JavaLoggingTest {
         System.out.println("======print logEx");
         System.out.println(logEx.toString());
         System.out.println("======finish print logEx");
-        Assert.assertEquals("Invalid token", logEx.get(1).getErrorText());
-        Assert.assertEquals(4, logEx.get(1).getErrorCode());
+        // in this case expect a valid http reply with a json error message
+        HttpEventCollectorErrorHandler.ServerErrorException serverErrorException = (HttpEventCollectorErrorHandler.ServerErrorException) logEx.get(1);
+        Assert.assertEquals("Invalid token", serverErrorException.getErrorText());
+        Assert.assertEquals(4, serverErrorException.getErrorCode());
 
 
         for (List<HttpEventCollectorEventInfo> infos : errors) {
@@ -304,12 +304,10 @@ public final class HttpEventCollector_JavaLoggingTest {
         logEx.clear();
 
         //define error callback
-        HttpEventCollectorErrorHandler.onError(new HttpEventCollectorErrorHandler.ErrorCallback() {
-            public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {
-                synchronized (errors) {
-                    errors.add(data);
-                    logEx.add((HttpEventCollectorErrorHandler.ServerErrorException) ex);
-                }
+        HttpEventCollectorErrorHandler.onError((data, ex) -> {
+            synchronized (errors) {
+                errors.add(data);
+                logEx.add(ex);
             }
         });
 

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -14,48 +14,49 @@
  * under the License.
  */
 
-import java.io.*;
-import java.util.*;
-
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
-
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.junit.Assert;
 import org.junit.Test;
-import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 
 public final class HttpEventCollector_Log4j2Test {
     private String httpEventCollectorName = "Log4j2Test";
-    List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<List<HttpEventCollectorEventInfo>>();
-    List<HttpEventCollectorErrorHandler.ServerErrorException> logEx = new ArrayList<>();
+    final List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<>();
+    final List<Exception> logEx = new ArrayList<>();
 
     /**
      * sending a message via httplogging using log4j2 to splunk
      */
     @Test
-    public void canSendEventUsingLog4j2() throws Exception, IOException, InterruptedException {
+    public void canSendEventUsingLog4j2() throws Exception {
         TestUtil.enableHttpEventCollector();
         String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
         String loggerName = "splunkLogger4j2";
-        HashMap<String, String> userInputs = new HashMap<String, String>();
+        HashMap<String, String> userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         org.apache.logging.log4j.core.LoggerContext context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
         //use httplogger
-        List<String> msgs = new ArrayList<String>();
+        List<String> msgs = new ArrayList<>();
 
         Date date = new Date();
-        String jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for log4j2}", date.toString());
+        String jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for log4j2}", date);
 
         Logger logger = context.getLogger(loggerName);
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
 
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test error for log4j2}", date.toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test error for log4j2}", date);
         logger.error(jsonMsg);
         msgs.add(jsonMsg);
 
@@ -70,11 +71,11 @@ public final class HttpEventCollector_Log4j2Test {
      * sending a message via httplogging using log4j2 to splunk and set index, source and sourcetype
      */
     @Test
-    public void canSendEventUsingLog4j2WithOptions() throws Exception, IOException, InterruptedException {
+    public void canSendEventUsingLog4j2WithOptions() throws Exception {
 
         String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
         String loggerName = "splunkLogger4j2WithOptions";
-        HashMap<String, String> userInputs = new HashMap<String, String>();
+        HashMap<String, String> userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         userInputs.put("user_index", "main");
@@ -84,16 +85,16 @@ public final class HttpEventCollector_Log4j2Test {
 
         org.apache.logging.log4j.core.LoggerContext context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
         //use httplogger
-        List<String> msgs = new ArrayList<String>();
+        List<String> msgs = new ArrayList<>();
 
         Date date = new Date();
-        String jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for log4j2}", date.toString());
+        String jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for log4j2}", date);
 
         Logger logger = context.getLogger(loggerName);
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
 
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test error for log4j2}", date.toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test error for log4j2}", date);
         logger.error(jsonMsg);
         msgs.add(jsonMsg);
 
@@ -112,21 +113,20 @@ public final class HttpEventCollector_Log4j2Test {
 
         //clean out the events cache by setting send events immediately
         String loggerName = "splunkLoggerCountCleanCache";
-        HashMap<String, String> userInputs = new HashMap<String, String>();
+        HashMap<String, String> userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         LoggerContext context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
-        String jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging}", new Date().toString());
+        String jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging}", new Date());
         Logger logger = context.getLogger(loggerName);
         logger.info(jsonMsg);
 
         loggerName = "splunkBatchLoggerCount";
-        userInputs = new HashMap<String, String>();
+        userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         userInputs.put("user_batch_interval","0");
         userInputs.put("user_batch_size_count", "5");
-        userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_host", "host.example.com");
         userInputs.put("user_source", "splunktest_BatchCount");
         userInputs.put("user_sourcetype", "battlecat_BatchCount");
@@ -134,24 +134,24 @@ public final class HttpEventCollector_Log4j2Test {
         context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
         logger = context.getLogger(loggerName);
 
-        List<String> msgs = new ArrayList<String>();
+        List<String> msgs = new ArrayList<>();
 
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging1}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging1}", new Date());
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
         System.out.println("event 1");
         TestUtil.verifyNoEventSentToSplunk(msgs);
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging2}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging2}", new Date());
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
         System.out.println("event 2");
         TestUtil.verifyNoEventSentToSplunk(msgs);
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging3}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging3}", new Date());
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
         System.out.println("event 3");
         TestUtil.verifyNoEventSentToSplunk(msgs);
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging4}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging4}", new Date());
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
         System.out.println("event 4");
@@ -160,7 +160,7 @@ public final class HttpEventCollector_Log4j2Test {
         Thread.sleep(6000);
         TestUtil.verifyNoEventSentToSplunk(msgs);
 
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging5}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'this is a test event for java logging5}", new Date());
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
 
@@ -176,7 +176,7 @@ public final class HttpEventCollector_Log4j2Test {
     public void sendBatchedEventsByBatchsize() throws Exception {
         String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
         String loggerName = "splunkLoggerBatchSize";
-        HashMap<String, String> userInputs = new HashMap<String, String>();
+        HashMap<String, String> userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         userInputs.put("user_batch_size_bytes", "500");
@@ -188,13 +188,13 @@ public final class HttpEventCollector_Log4j2Test {
         LoggerContext context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
         Logger logger = context.getLogger(loggerName);
 
-        List<String> msgs = new ArrayList<String>();
+        List<String> msgs = new ArrayList<>();
         int size = 0;
-        String jsonMsg = String.format("{EventDate:%s, EventMsg:'test event for log4j size 1}", new Date().toString());
+        String jsonMsg = String.format("{EventDate:%s, EventMsg:'test event for log4j size 1}", new Date());
         logger.info(jsonMsg);
         size += jsonMsg.length();
         msgs.add(jsonMsg);
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'test event for log4j size 2}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'test event for log4j size 2}", new Date());
         size += jsonMsg.length();
         logger.info(jsonMsg);
         msgs.add(jsonMsg);
@@ -202,7 +202,7 @@ public final class HttpEventCollector_Log4j2Test {
         Thread.sleep(6000);
         TestUtil.verifyNoEventSentToSplunk(msgs);
 
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'test event for log4j size 3, adding more msg to exceed the maxsize}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'test event for log4j size 3, adding more msg to exceed the maxsize}", new Date());
         while (size + jsonMsg.length() < 550) {
             jsonMsg = String.format("%saaaaa", jsonMsg);
         }
@@ -222,12 +222,10 @@ public final class HttpEventCollector_Log4j2Test {
         errors.clear();
         logEx.clear();
         //define error callback
-        HttpEventCollectorErrorHandler.onError(new HttpEventCollectorErrorHandler.ErrorCallback() {
-            public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {
-                synchronized (errors) {
-                    errors.add(data);
-                    logEx.add((HttpEventCollectorErrorHandler.ServerErrorException) ex);
-                }
+        HttpEventCollectorErrorHandler.onError((data, ex) -> {
+            synchronized (errors) {
+                errors.add(data);
+                logEx.add(ex);
             }
         });
 
@@ -235,7 +233,7 @@ public final class HttpEventCollector_Log4j2Test {
         httpEventCollectorName = "wrongtoken";
         String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
         String loggerName = "errorHandlingInvalidTokenLog4j";
-        HashMap<String, String> userInputs = new HashMap<String, String>();
+        HashMap<String, String> userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         LoggerContext context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
@@ -244,14 +242,14 @@ public final class HttpEventCollector_Log4j2Test {
         //disable the token so that it becomes invalid
         TestUtil.disableHttpEventCollector(httpEventCollectorName);
         Thread.sleep(5000);
-        String jsonMsg = String.format("{EventDate:%s, EventMsg:'test event disabled token }", new Date().toString());
+        String jsonMsg = String.format("{EventDate:%s, EventMsg:'test event disabled token }", new Date());
         logger.info(jsonMsg);
         Thread.sleep(5000);
 
         //delete the token so that it becomes invalid
         TestUtil.deleteHttpEventCollectorToken(httpEventCollectorName);
         Thread.sleep(5000);
-        jsonMsg = String.format("{EventDate:%s, EventMsg:'test event deleted token}", new Date().toString());
+        jsonMsg = String.format("{EventDate:%s, EventMsg:'test event deleted token}", new Date());
         logger.info(jsonMsg);
 
         //wait for async process to return the error
@@ -262,9 +260,6 @@ public final class HttpEventCollector_Log4j2Test {
             Thread.sleep(1000);
         }
 
-        if (logEx == null)
-            Assert.fail("didn't catch errors");
-
         for (List<HttpEventCollectorEventInfo> infos : errors) {
             for (HttpEventCollectorEventInfo info : infos) {
                 System.out.println(info.getMessage());
@@ -272,10 +267,15 @@ public final class HttpEventCollector_Log4j2Test {
         }
 
         System.out.println("======print logEx");
-        System.out.println(logEx.toString());
+        System.out.println(logEx);
         System.out.println("======finish print logEx");
-        Assert.assertEquals("Invalid token", logEx.get(1).getErrorText());
-        Assert.assertEquals(4, logEx.get(1).getErrorCode());
+        // in this case expect a valid http reply with a json error message
+        HttpEventCollectorErrorHandler.ServerErrorException serverErrorException1 = (HttpEventCollectorErrorHandler.ServerErrorException) logEx.get(0);
+        Assert.assertEquals("Token disabled", serverErrorException1.getErrorText());
+        Assert.assertEquals(1, serverErrorException1.getErrorCode());
+        HttpEventCollectorErrorHandler.ServerErrorException serverErrorException2 = (HttpEventCollectorErrorHandler.ServerErrorException) logEx.get(1);
+        Assert.assertEquals("Invalid token", serverErrorException2.getErrorText());
+        Assert.assertEquals(4, serverErrorException2.getErrorCode());
 
 
         Assert.assertEquals(2, errors.size());
@@ -291,12 +291,10 @@ public final class HttpEventCollector_Log4j2Test {
         logEx.clear();
 
         //define error callback
-        HttpEventCollectorErrorHandler.onError(new HttpEventCollectorErrorHandler.ErrorCallback() {
-            public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {
-                synchronized (errors) {
-                    errors.add(data);
-                    logEx.add((HttpEventCollectorErrorHandler.ServerErrorException) ex);
-                }
+        HttpEventCollectorErrorHandler.onError((data, ex) -> {
+            synchronized (errors) {
+                errors.add(data);
+                logEx.add(ex);
             }
         });
 
@@ -304,7 +302,7 @@ public final class HttpEventCollector_Log4j2Test {
         httpEventCollectorName = "wrongtoken";
         String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
         String loggerName = "errorHandlingDisabledHttpEventCollectorEndpoint";
-        HashMap<String, String> userInputs = new HashMap<String, String>();
+        HashMap<String, String> userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         LoggerContext context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
@@ -314,7 +312,7 @@ public final class HttpEventCollector_Log4j2Test {
         //disable httpEventCollector endpoint
         TestUtil.disableHttpEventCollector();
         Thread.sleep(1000);
-        String jsonMsg = String.format("{EventDate:%s, EventMsg:'test event httpEventCollector disabled}", new Date().toString());
+        String jsonMsg = String.format("{EventDate:%s, EventMsg:'test event httpEventCollector disabled}", new Date());
         logger.info(jsonMsg);
 
         //wait for async process to return the error
@@ -325,13 +323,11 @@ public final class HttpEventCollector_Log4j2Test {
             Thread.sleep(1000);
         }
 
-        if (logEx == null)
-            Assert.fail("didn't catch errors");
         Assert.assertTrue(errors.size() >= 1);
 
-        System.out.println(logEx.toString());
+        System.out.println(logEx);
         if (!StringUtils.containsAny(logEx.toString(), "Failed to connect to", "Remote host terminated the handshake", "Connection reset"))
-            Assert.fail(String.format("Unexpected error message '%s'", logEx.toString()));
+            Assert.fail(String.format("Unexpected error message '%s'", logEx));
     }
 
     /**
@@ -345,7 +341,7 @@ public final class HttpEventCollector_Log4j2Test {
         TestUtil.createIndex(indexName);
         String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
         String loggerName = "splunkLogger4j2OrderOfSent";
-        HashMap<String, String> userInputs = new HashMap<String, String>();
+        HashMap<String, String> userInputs = new HashMap<>();
         userInputs.put("user_logger_name", loggerName);
         userInputs.put("user_httpEventCollector_token", token);
         userInputs.put("user_index", indexName);
@@ -354,8 +350,7 @@ public final class HttpEventCollector_Log4j2Test {
         org.apache.logging.log4j.core.LoggerContext context = TestUtil.resetLog4j2Configuration("log4j2_template.xml", "log4j2.xml", userInputs);
 
         //send multiple events and verify they are indexed in the order of sending
-        List<String> msgs = new ArrayList<String>();
-        Date date = new Date();
+        List<String> msgs = new ArrayList<>();
         int totalEventsCount = 1000;
         Logger logger = context.getLogger(loggerName);
         String prefix="log4j2 multiple events";
@@ -386,8 +381,7 @@ public final class HttpEventCollector_Log4j2Test {
     public void canSendJsonEventUsingUtilLoggerWithDefaultSourceType() throws Exception {
         canSendJsonEventUsingUtilLoggerWithSourceType("battlecat_test");
     }
-    
-    @SuppressWarnings("unchecked")
+
     private void canSendJsonEventUsingUtilLoggerWithSourceType(final String sourceType) throws Exception {
         final String token = TestUtil.createHttpEventCollectorToken(httpEventCollectorName);
 
@@ -400,7 +394,7 @@ public final class HttpEventCollector_Log4j2Test {
         
         final Logger logger = context.getLogger(loggerName);
 
-        final List<String> msgs = new ArrayList<String>();
+        final List<String> msgs = new ArrayList<>();
 
         final long timeMillsec = new Date().getTime();
 

--- a/src/test/java/HttpEventCollector_LogbackTest.java
+++ b/src/test/java/HttpEventCollector_LogbackTest.java
@@ -14,6 +14,7 @@
  * under the License.
  */
 
+import java.rmi.server.ExportException;
 import java.util.*;
 
 import com.google.gson.JsonObject;
@@ -30,8 +31,8 @@ import org.slf4j.LoggerFactory;
 public final class HttpEventCollector_LogbackTest {
 
     private String httpEventCollectorName = "LogbackTest";
-    List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<List<HttpEventCollectorEventInfo>>();
-    List<HttpEventCollectorErrorHandler.ServerErrorException> logEx = new ArrayList<HttpEventCollectorErrorHandler.ServerErrorException>();
+    List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<>();
+    List<Exception> logEx = new ArrayList<>();
 
     /**
      * sending a message via httplogging using logback to splunk
@@ -260,8 +261,10 @@ public final class HttpEventCollector_LogbackTest {
         System.out.println("======print logEx");
         System.out.println(logEx.toString());
         System.out.println("======finish print logEx");
-        Assert.assertEquals("Invalid token", logEx.get(1).getErrorText());
-        Assert.assertEquals(4, logEx.get(1).getErrorCode());
+        // in this case expect a valid http reply with a json error message
+        HttpEventCollectorErrorHandler.ServerErrorException serverErrorException = (HttpEventCollectorErrorHandler.ServerErrorException) logEx.get(1);
+        Assert.assertEquals("Invalid token", serverErrorException.getErrorText());
+        Assert.assertEquals(4, serverErrorException.getErrorCode());
 
 
         for (List<HttpEventCollectorEventInfo> infos : errors) {
@@ -286,7 +289,7 @@ public final class HttpEventCollector_LogbackTest {
             public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {
                 synchronized (errors) {
                     errors.add(data);
-                    logEx.add((HttpEventCollectorErrorHandler.ServerErrorException) ex);
+                    logEx.add(ex);
                 }
             }
         });

--- a/src/test/java/HttpEventCollector_Test.java
+++ b/src/test/java/HttpEventCollector_Test.java
@@ -200,13 +200,11 @@ public class HttpEventCollector_Test {
     }
 
     private void LogToSplunk(boolean batching) throws Exception {
-        HttpEventCollectorErrorHandler.onError(new HttpEventCollectorErrorHandler.ErrorCallback() {
-            public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {
-                HttpEventCollectorErrorHandler.ServerErrorException serverErrorException =
-                        (HttpEventCollectorErrorHandler.ServerErrorException) ex;
-                System.out.printf("ERROR: %s", ex.toString());
-                Assert.assertTrue(false);
-            }
+        HttpEventCollectorErrorHandler.onError((data, ex) -> {
+            HttpEventCollectorErrorHandler.ServerErrorException serverErrorException =
+                    (HttpEventCollectorErrorHandler.ServerErrorException) ex;
+            System.out.printf("ERROR: %s", ex.toString());
+            Assert.assertTrue(false);
         });
         int expectedCounter = 2;
         System.out.printf("\tSetting up http event collector with %s ... ", batching ? "batching" : "no batching");
@@ -265,13 +263,11 @@ public class HttpEventCollector_Test {
     @Test
     public  void ResendDataToSplunk() throws  Exception
     {
-        HttpEventCollectorErrorHandler.onError(new HttpEventCollectorErrorHandler.ErrorCallback() {
-            public void error(final List<HttpEventCollectorEventInfo> data, final Exception ex) {
-                HttpEventCollectorErrorHandler.ServerErrorException serverErrorException =
-                        (HttpEventCollectorErrorHandler.ServerErrorException) ex;
-                System.out.printf("ERROR: %s", ex.toString());
-                Assert.assertTrue(false);
-            }
+        HttpEventCollectorErrorHandler.onError((data, ex) -> {
+            HttpEventCollectorErrorHandler.ServerErrorException serverErrorException =
+                    (HttpEventCollectorErrorHandler.ServerErrorException) ex;
+            System.out.printf("ERROR: %s", ex.toString());
+            Assert.assertTrue(false);
         });
         boolean batching = false;
         System.out.printf("\tSetting up http event collector with %s ... ", batching ? "batching" : "no batching");

--- a/src/test/java/com/splunk/logging/HttpEventCollectorErrorHandlerTest.java
+++ b/src/test/java/com/splunk/logging/HttpEventCollectorErrorHandlerTest.java
@@ -1,0 +1,90 @@
+package com.splunk.logging;
+
+import com.splunk.logging.util.StandardErrorCallback;
+import junit.framework.TestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HttpEventCollectorErrorHandlerTest extends TestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // reset error handler for each test
+        HttpEventCollectorErrorHandler.onError(null);
+    }
+
+    public void testRegisterClassName() {
+        // should not throw exceptions
+        HttpEventCollectorErrorHandler.registerClassName(null);
+        HttpEventCollectorErrorHandler.registerClassName("");
+        HttpEventCollectorErrorHandler.registerClassName("NonExistentClass");
+        HttpEventCollectorErrorHandler.registerClassName("com.splunk.logging.util.StandardErrorCallback");
+        HttpEventCollectorErrorHandler.registerClassName("com.splunk.logging.util.StandardErrorCallback");
+    }
+
+    public void testOnErrorDoubleRegisterAndCounters() {
+        StandardErrorCallback standardErrorCallback = new StandardErrorCallback();
+        // double register should be ok
+        HttpEventCollectorErrorHandler.onError(standardErrorCallback);
+        HttpEventCollectorErrorHandler.onError(standardErrorCallback);
+
+        HttpEventCollectorErrorHandler.error(createHttpEventCollectorEventInfos(), new RuntimeException("test"));
+
+        assertEquals(1, standardErrorCallback.getErrorCount());
+        assertEquals(2, standardErrorCallback.getEventCount());
+    }
+
+    public void testOnErrorCounters() {
+        StandardErrorCallback standardErrorCallback = new StandardErrorCallback();
+        HttpEventCollectorErrorHandler.onError(standardErrorCallback);
+
+        HttpEventCollectorErrorHandler.error(createHttpEventCollectorEventInfos(), new RuntimeException("test"));
+
+        assertEquals(1, standardErrorCallback.getErrorCount());
+        assertEquals(2, standardErrorCallback.getEventCount());
+
+        standardErrorCallback.resetCounters();
+
+        assertEquals(0, standardErrorCallback.getErrorCount());
+        assertEquals(0, standardErrorCallback.getEventCount());
+    }
+
+    public void testError() {
+        HttpEventCollectorErrorHandler.error(null, null);
+
+        HttpEventCollectorErrorHandler.onError((data, exception) -> {
+            assertNull(data);
+            assertNull(exception);
+        });
+
+        HttpEventCollectorErrorHandler.error(null, null);
+
+        HttpEventCollectorErrorHandler.onError((data, exception) -> {
+            assertTrue(exception.getMessage().contains("test exception"));
+            assertEquals(2, data.size());
+            assertEquals("FATAL", data.get(0).getSeverity());
+        });
+
+        List<HttpEventCollectorEventInfo> data = createHttpEventCollectorEventInfos();
+
+        HttpEventCollectorErrorHandler.error(data, new IllegalArgumentException("test exception"));
+
+        HttpEventCollectorErrorHandler.error(data, new HttpEventCollectorErrorHandler.ServerErrorException("{ 'text':'test exception', 'code':4}"));
+
+    }
+
+    @NotNull
+    private List<HttpEventCollectorEventInfo> createHttpEventCollectorEventInfos() {
+        List<HttpEventCollectorEventInfo> data = new ArrayList<>();
+        Map<String, String> map = new HashMap<>();
+        map.put("name", "value");
+        data.add(new HttpEventCollectorEventInfo(0, "FATAL", "message", "logger-name", "thread-name", map, "exception-message", "marker"));
+        data.add(new HttpEventCollectorEventInfo(1, "INFO", "message", "logger-name", "thread-name", map, "exception-message", "marker"));
+        return data;
+    }
+}

--- a/src/test/resources/log4j2_template.xml
+++ b/src/test/resources/log4j2_template.xml
@@ -18,6 +18,7 @@
               middleware="%user_middleware%"
               eventBodySerializer="%user_eventBodySerializer%"
               eventHeaderSerializer="%user_eventHeaderSerializer%"
+              errorCallback="%user_errorCallback%"
                 >
 
             <PatternLayout pattern="%m"/>

--- a/src/test/resources/logback_template.xml
+++ b/src/test/resources/logback_template.xml
@@ -18,6 +18,7 @@
         <middleware>%user_middleware%</middleware>
         <eventBodySerializer>%user_eventBodySerializer%</eventBodySerializer>
         <eventHeaderSerializer>%user_eventHeaderSerializer%</eventHeaderSerializer>
+        <errorCallback>%user_errorCallback%</errorCallback>
 
         <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%msg</pattern>

--- a/src/test/resources/logging_template.properties
+++ b/src/test/resources/logging_template.properties
@@ -22,6 +22,7 @@ com.splunk.logging.HttpEventCollectorLoggingHandler.retries_on_error = %user_ret
 
 com.splunk.logging.HttpEventCollectorLoggingHandler.eventBodySerializer = %user_eventBodySerializer%
 com.splunk.logging.HttpEventCollectorLoggingHandler.eventHeaderSerializer = %user_eventHeaderSerializer%
+com.splunk.logging.HttpEventCollectorLoggingHandler.errorCallback = %user_errorCallback%
 
 # You would usually use XMLFormatter or SimpleFormatter for this property, but
 # SimpleFormatter doesn't accept a format string under Java 6, and so we cannot


### PR DESCRIPTION
The `StandardErrorCallback` class can be registered via the `errorCallback` field in log4j/logback/java-logging config.
It logs to std err.

This is for issue [214](https://github.com/splunk/splunk-library-javalogging/issues/214).

Or custom errorCallbacks can be registered.

When using the `StandardErrorCallback` the following property can be used to also log  stack traces:

    -Dcom.splunk.logging.util.StandardErrorCallback.enablePrintStackTrace=true

Note this PR also includes a little change working with `com.splunk.logging.HttpEventCollectorErrorHandler.ServerErrorException`: it seemed not to make sense to wrap regular exceptions (e.g. non-Splunk errors that have json message with error code) inside a `ServerErrorException`. 