### PR TITLE
Upgrade Log4J again v2.17.0 related to CVE-2021-45046 & CVE-2021-44228 & CVE-2021-45105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Splunk Logging for Java Changelog
 
+## Version 1.11.3
+
+### Critical Security Update
+Upgrade Log4J again v2.17.0 related to CVE-2021-45046 & CVE-2021-44228
+
 ## Version 1.11.2
 
 ### Critical Security Update

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Logging for Java
 
-#### Version 1.11.0
+#### Version 1.11.3
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,19 +5,23 @@
 
     <groupId>com.splunk.logging</groupId>
     <artifactId>splunk-library-javalogging</artifactId>
-    <version>1.11.2</version>
+    <version>1.11.3</version>
     <packaging>jar</packaging>
 
     <name>Splunk Logging for Java</name>
-    <url>http://dev.splunk.com/goto/sdk-slj</url>
+    <url>https://dev.splunk.com/goto/sdk-slj</url>
 
-    <description>Library for structured, semantic logging of Common Information Model compliant events, meant for use
-        with SLF4J.
+    <description>
+        Library for structured, semantic logging of Common Information Model compliant events, meant for use with SLF4J.
     </description>
 
     <properties>
         <maven.resources.overwrite>true</maven.resources.overwrite>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- CVE-2021-44228: https://nvd.nist.gov/vuln/detail/CVE-2021-44228 -->
+        <!-- CVE-2021-45046: https://nvd.nist.gov/vuln/detail/CVE-2021-45046 -->
+        <log4j2.version>2.17.0</log4j2.version>
     </properties>
     <profiles>
         <profile>
@@ -214,14 +218,14 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <scope>provided</scope>
-            <version>2.16.0</version>
+            <version>${log4j2.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <scope>provided</scope>
-            <version>2.16.0</version>
+            <version>${log4j2.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Log4J-2.17.0
* CVE-2021-45105 - https://nvd.nist.gov/vuln/detail/CVE-2021-44228
* CVE-2021-45046 - https://nvd.nist.gov/vuln/detail/CVE-2021-45046
* CVE-2021-44228 - https://nvd.nist.gov/vuln/detail/CVE-2021-45105 