### PR TITLE
[CVE-2021-42550] Update Logback to version 1.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Logging for Java
 
-#### Version 1.11.3
+#### Version 1.11.4
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 
@@ -35,7 +35,7 @@ You'll need Java version 8 or higher, from [OpenJDK](https://openjdk.java.net) o
 If you're using the Log4j 2, Simple Logging Facade for Java (SLF4J), or Logback logging frameworks in conjunction with Splunk logging for Java there are additional compatibility requirements. For more about logging framework requirements, see [Enable logging to HEC](https://dev.splunk.com/enterprise/docs/devtools/java/logging-java/howtouseloggingjava/enableloghttpjava/) and [Enable logging to TCP inputs](https://dev.splunk.com/enterprise/docs/devtools/java/logging-java/howtouseloggingjava/enablelogtcpjava). These frameworks require:
 * Log4j version 2.17.0
 * SLF4J version 1.7.30
-* Logback version 1.2.3
+* Logback version 1.2.9
 
 ## Documentation and resources
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.splunk.logging</groupId>
     <artifactId>splunk-library-javalogging</artifactId>
-    <version>1.11.3</version>
+    <version>1.11.4</version>
     <packaging>jar</packaging>
 
     <name>Splunk Logging for Java</name>
@@ -22,6 +22,9 @@
         <!-- CVE-2021-44228: https://nvd.nist.gov/vuln/detail/CVE-2021-44228 -->
         <!-- CVE-2021-45046: https://nvd.nist.gov/vuln/detail/CVE-2021-45046 -->
         <log4j2.version>2.17.0</log4j2.version>
+        
+        <!-- CVE-2021-42550: https://nvd.nist.gov/vuln/detail/CVE-2021-42550 -->
+        <logback.version>1.2.9</logback.version>
     </properties>
     <profiles>
         <profile>
@@ -192,19 +195,19 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>${logback.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.2.3</version>
+            <version>${logback.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>
-            <version>1.2.3</version>
+            <version>${logback.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
In response to:
https://cve.report/CVE-2021-42550