### PR TITLE
Log4J-2.17.1 & Logback-1.2.10 for CVE-2021-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Splunk Logging for Java Changelog
 
+## Version 1.11.5
+### Critical Security Update
+* Bump Logback version to latest 1.2.10 @see [CVE-2021-42550 Logback<1.2.8](https://nvd.nist.gov/vuln/detail/CVE-2021-42550)
+* Bump Log4J version to latest 2.17.1 @see [CVE-2021-44832 Log4j<2.17.1](https://nvd.nist.gov/vuln/detail/CVE-2021-44832)
+### Minor Changes
+* Bump org.slf4j:slf4j-api version to latest [1.7.30](https://github.com/qos-ch/slf4j/releases/tag/v_1.7.32)
+* Bump com.squareup.okhttp3:okhttp to latest [4.9.3](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-493)
+* Bump com.google.code.gson:gson to latest [2.8.9](https://github.com/google/gson/releases/tag/gson-parent-2.8.9)
+
 ## Version 1.11.4
 
 ### Critical Security Update
@@ -8,7 +17,7 @@ Update Logback to version 1.2.9 per CVE-2021-42550.
 ## Version 1.11.3
 
 ### Critical Security Update
-Upgrade Log4J again v2.17.0 related to CVE-2021-45046 & CVE-2021-44228
+* Upgrade Log4J again v2.17.0 related to CVE-2021-45046 & CVE-2021-44228
 
 ## Version 1.11.2
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Logging for Java
 
-#### Version 1.11.4
+#### Version 1.11.5
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 
@@ -33,8 +33,8 @@ You'll need Java version 8 or higher, from [OpenJDK](https://openjdk.java.net) o
 #### Logging frameworks
 
 If you're using the Log4j 2, Simple Logging Facade for Java (SLF4J), or Logback logging frameworks in conjunction with Splunk logging for Java there are additional compatibility requirements. For more about logging framework requirements, see [Enable logging to HEC](https://dev.splunk.com/enterprise/docs/devtools/java/logging-java/howtouseloggingjava/enableloghttpjava/) and [Enable logging to TCP inputs](https://dev.splunk.com/enterprise/docs/devtools/java/logging-java/howtouseloggingjava/enablelogtcpjava). These frameworks require:
-* Log4j version 2.17.0
-* SLF4J version 1.7.30
+* Log4j version 2.17.1
+* SLF4J version 1.7.32
 * Logback version 1.2.9
 
 ## Documentation and resources

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
         <!-- https://logback.qos.ch/news.html -->
         <!-- CVE-2021-42550 (Logback<1.2.8): https://nvd.nist.gov/vuln/detail/CVE-2021-42550 -->
-        <logback.version>1.2.9</logback.version>
+        <logback.version>1.2.10</logback.version>
 
         <!-- https://logging.apache.org/log4j/2.x/security.html -->
         <!-- CVE-2021-44228 (Log4j<2.16.0): https://nvd.nist.gov/vuln/detail/CVE-2021-44228 -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.splunk.logging</groupId>
     <artifactId>splunk-library-javalogging</artifactId>
-    <version>1.11.4</version>
+    <version>1.11.5</version>
     <packaging>jar</packaging>
 
     <name>Splunk Logging for Java</name>
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -218,7 +218,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.1</version>
+            <version>4.9.3</version>
         </dependency>
 
         <dependency>
@@ -236,16 +236,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.splunk</groupId>
             <artifactId>splunk</artifactId>
             <version>1.6.5.0</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.7</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,16 @@
         <maven.resources.overwrite>true</maven.resources.overwrite>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- CVE-2021-44228: https://nvd.nist.gov/vuln/detail/CVE-2021-44228 -->
-        <!-- CVE-2021-45046: https://nvd.nist.gov/vuln/detail/CVE-2021-45046 -->
-        <log4j2.version>2.17.0</log4j2.version>
+        <!-- https://logback.qos.ch/news.html -->
+        <!-- CVE-2021-42550 (Logback<1.2.8): https://nvd.nist.gov/vuln/detail/CVE-2021-42550 -->
+        <logback.version>1.2.9</logback.version>
+
+        <!-- https://logging.apache.org/log4j/2.x/security.html -->
+        <!-- CVE-2021-44228 (Log4j<2.16.0): https://nvd.nist.gov/vuln/detail/CVE-2021-44228 -->
+        <!-- CVE-2021-45046 (Log4j<2.16.0): https://nvd.nist.gov/vuln/detail/CVE-2021-45046 -->
+        <!-- CVE-2021-45105 (Log4j<2.17.0): https://nvd.nist.gov/vuln/detail/CVE-2021-45105 -->
+        <!-- CVE-2021-44832 (Log4j<2.17.1): https://nvd.nist.gov/vuln/detail/CVE-2021-44832 -->
+        <log4j2.version>2.17.1</log4j2.version>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
## Version 1.11.5
### Critical Security Update
* Bump Logback version to latest 1.2.10 @see [CVE-2021-42550 Logback<1.2.8](https://nvd.nist.gov/vuln/detail/CVE-2021-42550)
* Bump Log4J version to latest 2.17.1 @see [CVE-2021-44832 Log4j<2.17.1](https://nvd.nist.gov/vuln/detail/CVE-2021-44832)
### Minor Changes
* Bump org.slf4j:slf4j-api version to latest [1.7.30](https://github.com/qos-ch/slf4j/releases/tag/v_1.7.32)
* Bump com.squareup.okhttp3:okhttp to latest [4.9.3](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-493)
* Bump com.google.code.gson:gson to latest [2.8.9](https://github.com/google/gson/releases/tag/gson-parent-2.8.9)

