### PR TITLE
Bump okhttp from 4.9.1 to 4.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.1</version>
+            <version>4.9.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumped okhttp to get latest security patch that fixes [CVE-2021-0341](https://nvd.nist.gov/vuln/detail/CVE-2021-0341)
Fixed in 4.9.2 but figured we could bump to the latest patch release.

[okhttp changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-493)