### PR TITLE
Security update: Patch vuln related to okhttp3 dep CVE-2021-0341

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.1</version>
+            <version>4.9.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <!-- CVE-2021-44228: https://nvd.nist.gov/vuln/detail/CVE-2021-44228 -->
         <!-- CVE-2021-45046: https://nvd.nist.gov/vuln/detail/CVE-2021-45046 -->
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         
         <!-- CVE-2021-42550: https://nvd.nist.gov/vuln/detail/CVE-2021-42550 -->
         <logback.version>1.2.9</logback.version>
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.7</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION

This should fix the critical vulnerability ( CVE-2021-0341) found in the "okhttp3" dependency.
Okhttp3 changelog: https://square.github.io/okhttp/changelogs/changelog_4x/
Vuln info: https://nvd.nist.gov/vuln/detail/CVE-2021-0341
Okhttp3 fix pr: https://github.com/square/okhttp/pull/6740