### PR TITLE
Issue 148: Fix invalid JsonHttpContentType

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorSender.java
@@ -42,7 +42,7 @@ public class HttpEventCollectorSender extends TimerTask implements HttpEventColl
     private static final String AuthorizationHeaderScheme = "Splunk %s";
     private static final String HttpEventCollectorUriPath = "/services/collector/event/1.0";
     private static final String HttpRawCollectorUriPath = "/services/collector/raw";
-    private static final String JsonHttpContentType = "application/json; profile=urn:splunk:event:1.0; charset=utf-8";
+    private static final String JsonHttpContentType = "application/json; profile=\"urn:splunk:event:1.0\"; charset=utf-8";
     private static final String PlainTextHttpContentType = "plain/text; charset=utf-8";
     private static final String SendModeSequential = "sequential";
     private static final String SendModeSParallel = "parallel";


### PR DESCRIPTION
The JsonHttpContentType does not conform to [RFC7231](https://httpwg.org/specs/rfc7231.html#media.type) specs, because it contains unquoted :. That causes okhttp3.MediaType.parse(JsonHttpContentType) to fail and return null, which isn't the intended behavior.
