### PR TITLE
chore: force okio version and upgrade okhttp3 to latest stable release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,13 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.3</version>
+            <version>4.11.0</version>
+        </dependency>
+        <dependency>
+            <!-- Force okio 3.5.0 until okhttp3 5.0.0 is released. Mitigates CVE-2023-3635 -->
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>3.5.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,12 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.11.0</version>
+            <exclusions>
+            <exclusion>
+                <artifactId>okio</artifactId>
+                <groupId>com.squareup.okio</groupId>
+            </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <!-- Force okio 3.5.0 until okhttp3 5.0.0 is released. Mitigates CVE-2023-3635 -->


### PR DESCRIPTION
The following PR upgrades `okhttp3` to the latest available stable version. Due to a CVE released for the transitive dependency `okio`. Unfortunately, no stable version of `okhttp3` exists that we can upgrade to. 

This PR excludes `okio` from the dependency resolution of `okhttp3` and adds it as a direct dependency instead.

According to https://github.com/square/okhttp/issues/7944 this is the recommendation by the maintainers. There is no timeline for a 4.12.x release to mitigate this yet.

This is what the updated depdendency tree looks like


```
[INFO] --- dependency:3.6.0:tree (default-cli) @ splunk-library-javalogging ---
[INFO] com.splunk.logging:splunk-library-javalogging:jar:1.11.7
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.slf4j:slf4j-api:jar:1.7.36:test (scope not updated to provided)
[INFO] +- ch.qos.logback:logback-classic:jar:1.2.11:provided
[INFO] |  +- (ch.qos.logback:logback-core:jar:1.2.11:provided - omitted for duplicate)
[INFO] |  \- (org.slf4j:slf4j-api:jar:1.7.32:provided - omitted for conflict with 1.7.36)
[INFO] +- ch.qos.logback:logback-core:jar:1.2.11:provided (scope not updated to provided)
[INFO] +- ch.qos.logback:logback-access:jar:1.2.11:provided
[INFO] |  \- (ch.qos.logback:logback-core:jar:1.2.11:provided - omitted for duplicate)
[INFO] +- com.squareup.okhttp3:okhttp:jar:4.11.0:compile
[INFO] |  +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20:compile
[INFO] |  |  +- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.6.20:compile
[INFO] |  |  \- org.jetbrains:annotations:jar:13.0:compile
[INFO] |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.6.20:compile
[INFO] |     +- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20:compile - omitted for duplicate)
[INFO] |     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.6.20:compile
[INFO] |        \- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20:compile - omitted for duplicate)
[INFO] +- com.squareup.okio:okio:jar:3.5.0:compile
[INFO] |  \- com.squareup.okio:okio-jvm:jar:3.5.0:compile
[INFO] |     +- (org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.9.0:compile - omitted for conflict with 1.6.20)
[INFO] |     \- (org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.9.0:compile - omitted for conflict with 1.6.20)
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.17.2:provided
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.17.2:provided
[INFO] |  \- (org.apache.logging.log4j:log4j-api:jar:2.17.2:provided - omitted for duplicate)
[INFO] +- com.splunk:splunk:jar:1.6.5.0:test
[INFO] +- com.google.code.gson:gson:jar:2.9.0:compile
[INFO] \- org.apache.commons:commons-lang3:jar:3.12.0:test
```