### PR TITLE
Logback Encoder Support for HEC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,20 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     container: maven:3-jdk-8
 
-    services:
-      splunk:
-        image: splunk/splunk:${{matrix.splunk-version}}
-        env:
-          SPLUNK_START_ARGS: --accept-license
-          SPLUNK_PASSWORD: changed!
-        ports:
-          - 8089
-          - 8088
-          - 5555
-          - 15000
-          - 10667
-          - 10668/udp
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -73,3 +59,4 @@ jobs:
         env:
           SPLUNK_PASSWORD: changed!
           SPLUNK_HOST: splunk
+          USE_IMAGE_VERSION: ${{matrix.splunk-version}}

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
                         <version>2.22.2</version>
                         <configuration>
                             <includes>
-                                <include>**/HttpEventCollector_*.class</include>
+                                <include>**/TestSuiteAcceptanceTests.class</include>
                             </includes>
                         </configuration>
                     </plugin>
@@ -160,7 +160,7 @@
                         <version>2.22.2</version>
                         <configuration>
                             <includes>
-                                <include>**/HttpLoggerStressTest.class</include>
+                                <include>**/TestSuiteStressTests.class</include>
                             </includes>
                         </configuration>
                     </plugin>
@@ -196,6 +196,18 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.20.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>7.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/HttpEventCollector_Log4j2Test.java
+++ b/src/test/java/HttpEventCollector_Log4j2Test.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 
 public final class HttpEventCollector_Log4j2Test {
+
     private String httpEventCollectorName = "Log4j2Test";
     final List<List<HttpEventCollectorEventInfo>> errors = new ArrayList<>();
     final List<Exception> logEx = new ArrayList<>();

--- a/src/test/java/HttpEventCollector_Test.java
+++ b/src/test/java/HttpEventCollector_Test.java
@@ -17,22 +17,25 @@
  */
 
 import ch.qos.logback.core.joran.spi.JoranException;
+import com.splunk.*;
 import com.splunk.logging.HttpEventCollectorErrorHandler;
 import com.splunk.logging.HttpEventCollectorEventInfo;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.*;
-import java.lang.reflect.*;
-
-import com.splunk.*;
-import org.slf4j.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 
 public class HttpEventCollector_Test {
+
     public static void addPath(String s) throws Exception {
         File f = new File(s);
         URI u = f.toURI();

--- a/src/test/java/TestRuleSplunkContainer.java
+++ b/src/test/java/TestRuleSplunkContainer.java
@@ -13,10 +13,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TestRuleSplunkContainer implements TestRule {
+    // Allow choosing image version from CI
+    private static String dockerImageName() {
+        String version = System.getenv().getOrDefault("USE_IMAGE_VERSION", "latest");
+        return String.join(
+                ":",
+                "splunk/splunk",
+                version);
+    }
+
     @Override
     public Statement apply(Statement base, Description description) {
         try (
-                GenericContainer<?> splunk = new FixedHostPortGenericContainer<>("splunk/splunk:latest")
+                GenericContainer<?> splunk = new FixedHostPortGenericContainer<>(dockerImageName())
                         .withFixedExposedPort(8000, 8000)
                         .withFixedExposedPort(5555, 5555)
                         .withFixedExposedPort(8088, 8088)

--- a/src/test/java/TestRuleSplunkContainer.java
+++ b/src/test/java/TestRuleSplunkContainer.java
@@ -1,0 +1,61 @@
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.InternetProtocol;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestRuleSplunkContainer implements TestRule {
+    @Override
+    public Statement apply(Statement base, Description description) {
+        try (
+                GenericContainer<?> splunk = new FixedHostPortGenericContainer<>("splunk/splunk:latest")
+                        .withFixedExposedPort(8000, 8000)
+                        .withFixedExposedPort(5555, 5555)
+                        .withFixedExposedPort(8088, 8088)
+                        .withFixedExposedPort(8089, 8089)
+                        .withFixedExposedPort(15000, 15000)
+                        .withFixedExposedPort(10667, 10667)
+                        .withFixedExposedPort(10668, 10668, InternetProtocol.UDP)
+                        .withExposedPorts(9997)
+                        .withEnv("SPLUNK_START_ARGS", "--accept-license")
+                        .withEnv("SPLUNK_PASSWORD", "changed!")
+                        .withStartupTimeout(Duration.ofMinutes(2L))
+                        .waitingFor(Wait.forListeningPorts(9997)) // must wait on an unfixed port
+        ) {
+            return wrapTestCase(base, splunk);
+        }
+    }
+
+    private Statement wrapTestCase(final Statement base, final GenericContainer<?> container) {
+        return new Statement() {
+            public void evaluate() throws Throwable {
+                List<Throwable> errors = new ArrayList<>();
+
+                try {
+                    // Pre-Test
+                    container.start();
+                    base.evaluate();
+                } catch (Throwable preError) {
+                    errors.add(preError);
+                } finally {
+                    // Post-Test
+                    try {
+                        container.stop();
+                    } catch (Throwable postError) {
+                        errors.add(postError);
+                    }
+                }
+
+                MultipleFailureException.assertEmpty(errors);
+            }
+        };
+    }
+}

--- a/src/test/java/TestSuiteAcceptanceTests.java
+++ b/src/test/java/TestSuiteAcceptanceTests.java
@@ -1,0 +1,15 @@
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        HttpEventCollector_JavaLoggingTest.class,
+        HttpEventCollector_Log4j2Test.class,
+        HttpEventCollector_LogbackTest.class,
+        HttpEventCollector_Test.class
+})
+public class TestSuiteAcceptanceTests {
+    @ClassRule
+    public static final TestRuleSplunkContainer TEST_CONTAINER = new TestRuleSplunkContainer();
+}

--- a/src/test/java/TestSuiteStressTests.java
+++ b/src/test/java/TestSuiteStressTests.java
@@ -1,0 +1,12 @@
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        HttpLoggerStressTest.class
+})
+public class TestSuiteStressTests {
+    @ClassRule
+    public static final TestRuleSplunkContainer TEST_CONTAINER = new TestRuleSplunkContainer();
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -57,13 +57,11 @@ under the License.
         <token>11111111-2222-3333-4444-555555555555</token>
         <source>splunktest</source>
         <sourcetype>battlecat</sourcetype>
-        <messageFormat>text</messageFormat>
+        <messageFormat>json</messageFormat>
         <middleware>HttpEventCollectorUnitTestMiddleware</middleware>
         <connectTimeout>5000</connectTimeout>
         <terminationTimeout>2000</terminationTimeout>
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%msg</pattern>
-        </layout>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
     <logger name="splunk.logger" additivity="false" level="INFO">


### PR DESCRIPTION
# Logback Encoder Support for HEC
__Related Issues:__ #284 

## PR Summary

Encoders are now supported for the HEC appender, with layout now deprecated in the same fashion as the TCP appender. I have verified that JSON payloads are correctly sent using the popular [logstash-logback-encoder](https://github.com/logfellow/logstash-logback-encoder) with `messageFormat` set to `json`.
__Acceptance and Stress Suites are all green.__

## PR Changes

- `HttpEventCollectorLogbackAppender` accepts an encoder and automatically wraps a layout in the same manner as the tcp appender.
- Testcontainers integration for the Acceptance and Stress Suites. Testcontainers will spin up the splunk docker image automatically prior to suite execution.
- `net.logstash.logback.encoder.LogstashEncoder` with json message format utilized in the logback.xml to mimic real world usage within the test suite.
- Updated the GitHub Action workflow, `test.yml`, to work with the Testcontainers approach.

## PR Added Dependencies

- __test only__ - [org.testcontainers:testcontainers:1.20.1](https://mvnrepository.com/artifact/org.testcontainers/testcontainers/1.20.1)
- __test only__ - [net.logstash.logback:logstash-logback-encoder:7.3](https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder/7.3)