### PR TITLE
Preserve original server response in case of non json response body

### DIFF
--- a/src/main/java/com/splunk/logging/HttpEventCollectorErrorHandler.java
+++ b/src/main/java/com/splunk/logging/HttpEventCollectorErrorHandler.java
@@ -77,7 +77,7 @@ public class HttpEventCollectorErrorHandler {
                 errorCode = json.get("code").getAsLong();
                 errorText = json.get("text").getAsString();
             } catch (Exception e) {
-                errorText = e.getMessage();
+                errorText = serverReply;
             }
         }
 

--- a/src/test/java/com/splunk/logging/HttpEventCollectorErrorHandlerTest.java
+++ b/src/test/java/com/splunk/logging/HttpEventCollectorErrorHandlerTest.java
@@ -76,6 +76,7 @@ public class HttpEventCollectorErrorHandlerTest extends TestCase {
 
         HttpEventCollectorErrorHandler.error(data, new HttpEventCollectorErrorHandler.ServerErrorException("{ 'text':'test exception', 'code':4}"));
 
+        HttpEventCollectorErrorHandler.error(data, new HttpEventCollectorErrorHandler.ServerErrorException("Non Json response body: test exception"));
     }
 
     @NotNull


### PR DESCRIPTION
For issue https://github.com/splunk/splunk-library-javalogging/issues/267

Preserve the original server response when it cannot be parsed as JSON. This avoids replacing the server response with non helpful JSON parsing exception in the ServerErrorException.