### PR TITLE
Release 1.11.11 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Splunk Logging for Java Changelog
 
+## Version 1.11.11
+
+### Security Updates
+
+* Bump Logback to 1.3.16 (fixes CVE-2024-12798)
+* Bump slf4j-api to 2.0.7 for Logback 1.3.16 compatibility
+
 ## Version 1.11.10
 
 ### Security Updates

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Logging for Java
 
-## Version 1.11.10
+## Version 1.11.11
 
 Splunk logging for Java enables you to log events to HTTP Event Collector or to a TCP input on a Splunk Enterprise instance within your Java applications. You can use three major Java logging frameworks: [Logback](http://logback.qos.ch), [Log4j 2](http://logging.apache.org/log4j/2.x/), and [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html). Splunk logging for Java is also enabled for [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org).
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.splunk.logging</groupId>
     <artifactId>splunk-library-javalogging</artifactId>
 
-    <version>1.11.10</version>
+    <version>1.11.11</version>
 
     <packaging>jar</packaging>
 


### PR DESCRIPTION
## Summary
- Bump version to 1.11.11
- Logback 1.3.16 (CVE-2024-12798) and slf4j-api 2.0.7 bump already merged via #302; this bumps release version and changelog